### PR TITLE
Set default list of stocks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,11 +39,13 @@ fn main() {
     let ticker = tick(Duration::from_millis(1000));
     let ui_events = setup_ui_events();
 
-    let starting_stocks: Vec<_> = opts
-        .symbols
-        .into_iter()
-        .map(widget::StockState::new)
-        .collect();
+    let mut stocks = opts.symbols;
+
+    if stocks.is_empty() {
+        stocks = vec!["spy".into()];
+    }
+
+    let starting_stocks: Vec<_> = stocks.into_iter().map(widget::StockState::new).collect();
 
     let starting_mode = if starting_stocks.is_empty() {
         app::Mode::AddStock


### PR DESCRIPTION
If a user doesn't supply a list of stocks as an argument, then create a default list of stocks. For now, it just has `spy` 📈 

`cargo run` will open the program with `spy` loaded

![image](https://user-images.githubusercontent.com/6572184/90967260-7276ca80-e491-11ea-99d2-234337d3d87c.png)
