### PR TITLE
cache data

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -314,7 +314,7 @@ pub fn handle_keys_display_options<B: Backend>(
                     .options
                     .as_mut()
                     .unwrap()
-                    .data
+                    .data()
                     .is_some()
                 {
                     app.stocks[app.current_tab]

--- a/src/widget/stock_summary.rs
+++ b/src/widget/stock_summary.rs
@@ -89,7 +89,12 @@ impl StatefulWidget for StockSummaryWidget {
 
             let (min, max) = state.min_max();
 
-            let mut prices: Vec<_> = state.prices.iter().map(cast_historical_as_price).collect();
+            let mut prices: Vec<_> = state
+                .prices()
+                .iter()
+                .map(cast_historical_as_price)
+                .collect();
+
             prices.pop();
             prices.push(state.current_price);
             zeros_as_pre(&mut prices);


### PR DESCRIPTION
resolves #11 

This saves any data received over the API for stock and option data. Previously data would get discarded when choosing a new time frame or a new date for options.