### PR TITLE
add prev close line

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,9 @@ pub struct Opt {
     /// Hide toggle block
     pub hide_toggle: bool,
     #[structopt(long)]
+    /// Hide previous close line on 1D chart
+    pub hide_prev_close: bool,
+    #[structopt(long)]
     /// Start in summary mode
     pub summary: bool,
     #[structopt(short = "i", long, default_value = "1")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ lazy_static! {
     pub static ref UPDATE_INTERVAL: u64 = OPTS.update_interval;
     pub static ref TIME_FRAME: TimeFrame = OPTS.time_frame;
     pub static ref HIDE_TOGGLE: bool = OPTS.hide_toggle;
+    pub static ref HIDE_PREV_CLOSE: bool = OPTS.hide_prev_close;
     pub static ref REDRAW_REQUEST: (Sender<()>, Receiver<()>) = unbounded();
     pub static ref SHOW_X_LABELS: RwLock<bool> = RwLock::new(OPTS.show_x_labels);
 }


### PR DESCRIPTION
@daniel-j-h check this out. I've added a line on the `1D` time frame to mark previous close so you can easily visualize where it's plotted compared to that. This can be disabled with `--hide-prev-close`


![image](https://user-images.githubusercontent.com/10239377/92963974-2aabe900-f428-11ea-8f0c-b526a768b1e4.png)
![image](https://user-images.githubusercontent.com/10239377/92964168-870f0880-f428-11ea-9270-a14aac32d5d4.png)

