### PR TITLE
don't render until fully loaded

### DIFF
--- a/src/widget/stock.rs
+++ b/src/widget/stock.rs
@@ -278,7 +278,7 @@ impl StatefulWidget for StockWidget {
                     if loaded {
                         format!(" - {}", company_name)
                     } else if state.profile.is_some() {
-                        format!(" - {}{}", company_name, loading_indicator)
+                        format!(" - {}{:<4}", company_name, loading_indicator)
                     } else {
                         loading_indicator
                     }

--- a/src/widget/stock_summary.rs
+++ b/src/widget/stock_summary.rs
@@ -33,18 +33,24 @@ impl StatefulWidget for StockSummaryWidget {
         let loading_indicator = ".".repeat(state.loading_tick);
 
         let title = &format!(
-            " {}{:<4} ",
+            " {}{}",
             state.symbol,
-            if loaded {
+            if state.profile.is_some() {
                 format!(" - {}", company_name)
-            } else if state.profile.is_some() {
-                format!(" - {}{}", company_name, loading_indicator)
             } else {
-                loading_indicator
+                "".to_string()
             }
         );
         Block::default()
-            .title(&format!(" {} ", &title[..24.min(title.len())]))
+            .title(&format!(
+                " {}{} ",
+                &title[..24.min(title.len())],
+                if loaded {
+                    "".to_string()
+                } else {
+                    format!("{:<4}", loading_indicator)
+                }
+            ))
             .borders(Borders::TOP)
             .render(area, buf);
 

--- a/src/widget/stock_summary.rs
+++ b/src/widget/stock_summary.rs
@@ -20,16 +20,29 @@ impl StatefulWidget for StockSummaryWidget {
         let pct_change = state.pct_change();
 
         let loaded = state.loaded();
+        state.loading_tick();
 
         let (company_name, currency) = match state.profile.as_ref() {
             Some(profile) => (
                 profile.price.short_name.as_str(),
                 profile.price.currency.as_deref().unwrap_or("USD"),
             ),
-            None => ("Loading...", ""),
+            None => ("", ""),
         };
 
-        let title = format!("{} - {}", state.symbol, company_name);
+        let loading_indicator = ".".repeat(state.loading_tick);
+
+        let title = &format!(
+            " {}{:<4} ",
+            state.symbol,
+            if loaded {
+                format!(" - {}", company_name)
+            } else if state.profile.is_some() {
+                format!(" - {}{}", company_name, loading_indicator)
+            } else {
+                loading_indicator
+            }
+        );
         Block::default()
             .title(&format!(" {} ", &title[..24.min(title.len())]))
             .borders(Borders::TOP)


### PR DESCRIPTION
this partially addresses #23 & #22 (the other part being retries on the API request if failed). Those issues were caused by not having 100% of the needed API data. This holds off on rendering until we get all the needed data so things don't look incorrect / partial /  broken.

It'd be nice to add some sort of loading indicator. On my connection, loading takes less than a second so it won't be noticeable. But if for some reason loading the API data take a minute, it'd be nice to have a pronounced indicator.