### PR TITLE
Optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Huge improvements to optimization of program. CPU usage is way down (#54)
+
 ## [0.9.1] - 2021-02-06
 
 ### Changed

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -192,6 +193,17 @@ pub struct Price {
     pub date: i64,
 }
 
+impl Hash for Price {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.close.to_bits().hash(state);
+        self.volume.hash(state);
+        self.high.to_bits().hash(state);
+        self.low.to_bits().hash(state);
+        self.open.to_bits().hash(state);
+        self.date.hash(state);
+    }
+}
+
 pub fn chart_data_to_prices(mut chart_data: ChartData) -> Vec<Price> {
     if chart_data.indicators.quote.len() != 1 {
         return vec![];
@@ -223,7 +235,7 @@ pub fn cast_as_dataset(input: (usize, &f64)) -> (f64, f64) {
     ((input.0 + 1) as f64, *input.1)
 }
 
-pub fn cast_historical_as_price(input: Price) -> f64 {
+pub fn cast_historical_as_price(input: &Price) -> f64 {
     input.close
 }
 

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,6 +1,3 @@
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-
 use tui::backend::Backend;
 use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use tui::style::{Color, Style};
@@ -160,39 +157,9 @@ fn draw_main<B: Backend>(frame: &mut Frame<B>, app: &mut App, area: Rect) {
             vec![layout[1]]
         };
 
-        let mut hasher = DefaultHasher::default();
-        stock.hash(&mut hasher);
-        let hash = hasher.finish();
-
-        let cached_area = stock.cached_area;
-
-        if hash == stock.prev_hash
-            && cached_area.width == main_chunks[0].width
-            && cached_area.height == main_chunks[0].height
-        {
-            stock.use_cache = true;
-        } else if hash != stock.prev_hash {
-            stock.prev_hash = hash;
-        }
-
         frame.render_stateful_widget(StockWidget {}, main_chunks[0], stock);
 
         if let Some(options) = stock.options.as_mut() {
-            let mut hasher = DefaultHasher::default();
-            options.hash(&mut hasher);
-            let hash = hasher.finish();
-
-            let cached_area = options.cached_area;
-
-            if hash == options.prev_hash
-                && cached_area.width == main_chunks[1].width
-                && cached_area.height == main_chunks[1].height
-            {
-                options.use_cache = true;
-            } else if hash != options.prev_hash {
-                options.prev_hash = hash;
-            }
-
             frame.render_stateful_widget(OptionsWidget {}, main_chunks[1], options);
         }
     }
@@ -264,21 +231,6 @@ fn draw_summary<B: Backend>(frame: &mut Frame<B>, app: &mut App, area: Rect) {
     let stock_layout = Layout::default().constraints(contraints).split(layout[1]);
 
     for (idx, stock) in app.stocks[..num_to_render].iter_mut().enumerate() {
-        let mut hasher = DefaultHasher::default();
-        stock.hash(&mut hasher);
-        let hash = hasher.finish();
-
-        let cached_area = stock.cached_area;
-
-        if hash == stock.prev_hash
-            && cached_area.width == stock_layout[idx].width
-            && cached_area.height == stock_layout[idx].height
-        {
-            stock.use_cache = true;
-        } else if hash != stock.prev_hash {
-            stock.prev_hash = hash;
-        }
-
         frame.render_stateful_widget(StockSummaryWidget {}, stock_layout[idx], stock);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,11 @@ fn main() {
                 default(Duration::from_millis(500)) => {
                     let mut app = app.lock().unwrap();
 
+                    // Drive animation of loading icon
+                    for stock in app.stocks.iter_mut() {
+                        stock.loading_tick();
+                    }
+
                     draw::draw(&mut terminal, &mut app);
                 }
             }

--- a/src/task.rs
+++ b/src/task.rs
@@ -99,6 +99,6 @@ impl<R> AsyncTaskHandle<R> {
 impl<R> Drop for AsyncTaskHandle<R> {
     fn drop(&mut self) {
         let handle = self.handle.take().unwrap();
-        task::block_on(async { handle.cancel().await });
+        task::spawn(async { handle.cancel().await });
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -2,8 +2,9 @@ use std::time::{Duration, Instant};
 
 use async_std::sync::Arc;
 use async_std::task;
-use crossbeam_channel::{bounded, select, unbounded, Receiver, Sender};
+use crossbeam_channel::{unbounded, Receiver};
 use futures::future::BoxFuture;
+use task::JoinHandle;
 
 pub use self::company::Company;
 pub use self::current_price::CurrentPrice;
@@ -39,14 +40,13 @@ pub trait AsyncTask: 'static {
 
     /// Runs the task on the async runtime and returns a handle to query updates from
     fn connect(&self) -> AsyncTaskHandle<Self::Response> {
-        let (drop_sender, drop_receiver) = bounded::<()>(1);
         let (response_sender, response_receiver) = unbounded::<Self::Response>();
         let data_received = DATA_RECEIVED.0.clone();
 
         let update_interval = self.update_interval();
         let input = Arc::new(self.input());
 
-        task::spawn(async move {
+        let handle = task::spawn(async move {
             let mut last_updated = Instant::now();
 
             // Execute the task initially and request a redraw to display this data
@@ -62,7 +62,7 @@ pub trait AsyncTask: 'static {
                 return;
             };
 
-            // Execute task every update interval and exit if drop signal is received
+            // Execute task every update interval
             loop {
                 if last_updated.elapsed() >= update_interval {
                     if let Some(response) = <Self as AsyncTask>::task(input.clone()).await {
@@ -73,28 +73,21 @@ pub trait AsyncTask: 'static {
                     last_updated = Instant::now();
                 }
 
-                select! {
-                    recv(drop_receiver) -> drop => if let Ok(()) = drop {
-                        break;
-                    },
-                    default() => (),
-                }
-
                 // Free up some cycles
                 task::sleep(Duration::from_secs(1)).await;
             }
         });
 
         AsyncTaskHandle {
-            drop_sender: Some(drop_sender),
             response: response_receiver,
+            handle: Some(handle),
         }
     }
 }
 
 pub struct AsyncTaskHandle<R> {
-    drop_sender: Option<Sender<()>>,
     response: Receiver<R>,
+    handle: Option<JoinHandle<()>>,
 }
 
 impl<R> AsyncTaskHandle<R> {
@@ -105,8 +98,7 @@ impl<R> AsyncTaskHandle<R> {
 
 impl<R> Drop for AsyncTaskHandle<R> {
     fn drop(&mut self) {
-        if let Some(ref drop_sender) = self.drop_sender {
-            let _ = drop_sender.send(());
-        }
+        let handle = self.handle.take().unwrap();
+        task::block_on(async { handle.cancel().await });
     }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,8 +1,15 @@
-pub use add_stock::{AddStockState, AddStockWidget};
-pub use help::{HelpWidget, HELP_HEIGHT, HELP_WIDTH};
-pub use options::{OptionsState, OptionsWidget};
-pub use stock::{StockState, StockWidget};
-pub use stock_summary::StockSummaryWidget;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use tui::buffer::{Buffer, Cell};
+use tui::layout::Rect;
+use tui::widgets::StatefulWidget;
+
+pub use self::add_stock::{AddStockState, AddStockWidget};
+pub use self::help::{HelpWidget, HELP_HEIGHT, HELP_WIDTH};
+pub use self::options::{OptionsState, OptionsWidget};
+pub use self::stock::{StockState, StockWidget};
+pub use self::stock_summary::StockSummaryWidget;
 
 mod add_stock;
 pub mod block;
@@ -10,3 +17,59 @@ mod help;
 pub mod options;
 mod stock;
 mod stock_summary;
+
+pub trait CachableWidget<T: Hash>: StatefulWidget<State = T> + Sized {
+    fn cache_state_mut(state: &mut <Self as StatefulWidget>::State) -> &mut CacheState;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut <Self as StatefulWidget>::State);
+
+    fn render_cached(
+        self,
+        area: Rect,
+        buf: &mut Buffer,
+        state: &mut <Self as StatefulWidget>::State,
+    ) {
+        // Hash our state
+        let mut hasher = DefaultHasher::default();
+        state.hash(&mut hasher);
+        let hash = hasher.finish();
+
+        // Get previously cached values
+        let CacheState {
+            prev_area,
+            prev_content,
+            prev_hash,
+        } = <Self as CachableWidget<T>>::cache_state_mut(state).clone();
+
+        // If current hash and layout matches previous, use cached buffer instead of re-rendering
+        if hash == prev_hash && prev_area.width == area.width && prev_area.height == area.height {
+            for (idx, cell) in buf.content.iter_mut().enumerate() {
+                let x = idx as u16 % buf.area.width;
+                let y = idx as u16 / buf.area.width;
+
+                if x >= area.x && x < area.x + area.width && y >= area.y && y < area.y + area.height
+                {
+                    if let Some(cached_cell) = prev_content.get(idx) {
+                        *cell = cached_cell.clone();
+                    }
+                }
+            }
+        }
+        // Otherwise re-render and store those values in the cache
+        else {
+            <Self as CachableWidget<T>>::render(self, area, buf, state);
+
+            let cached_state = <Self as CachableWidget<T>>::cache_state_mut(state);
+            cached_state.prev_hash = hash;
+            cached_state.prev_area = area;
+            cached_state.prev_content = buf.content.clone();
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CacheState {
+    prev_area: Rect,
+    prev_hash: u64,
+    prev_content: Vec<Cell>,
+}


### PR DESCRIPTION
@miraclx Ok, check out this branch. CPU usage is WAY down, especially in summary mode with a bunch of tickers showing. I'm averaging ~3-5% CPU usage in summary mode with 10 stocks on 5yr timeframe. Compared to 0.9.1 uses ~60%.

I added layout caching so I don't have to re-render components if their hashed state & layout dimensions haven't changed. I also did some profiling and found the "prices" method I call a lot in the code is VERY expensive. It was being called inside many of the other methods. I made sure to only call this once per render loop, and pass the data in as a parameter where needed so it wasn't redundantly called.

I also made the change we discussed where I'm cancelling async tasks immediately when time frame is changed vs my previous method of sending a drop message to that future. Switching time frames, even in summary mode, is now instantly responsive. No more lag here.