### PR TITLE
Conditional mouse capture

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -38,6 +38,25 @@ impl App {
     }
 }
 
+pub struct EnvConfig {
+    pub show_debug: bool,
+    pub debug_mouse: bool,
+}
+
+impl EnvConfig {
+    #[inline]
+    fn env_match(key: &str, default: &str, expected: &str) -> bool {
+        std::env::var(key).ok().unwrap_or_else(|| default.into()) == expected
+    }
+
+    pub fn load() -> Self {
+        Self {
+            show_debug: Self::env_match("SHOW_DEBUG", "0", "1"),
+            debug_mouse: Self::env_match("DEBUG_MOUSE", "0", "1"),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct DebugInfo {
     pub enabled: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod widget;
 
 lazy_static! {
     static ref CLIENT: api::Client = api::Client::new();
+    static ref DEBUG_LEVEL: app::EnvConfig = app::EnvConfig::load();
     pub static ref OPTS: opts::Opts = opts::resolve_opts();
     pub static ref UPDATE_INTERVAL: u64 = OPTS.update_interval.unwrap_or(1);
     pub static ref TIME_FRAME: TimeFrame = OPTS.time_frame.unwrap_or(TimeFrame::Day1);
@@ -81,10 +82,7 @@ fn main() {
         current_tab: 0,
         hide_help: opts.hide_help,
         debug: DebugInfo {
-            enabled: std::env::var("SHOW_DEBUG")
-                .ok()
-                .unwrap_or_else(|| String::from("0"))
-                == "1",
+            enabled: DEBUG_LEVEL.show_debug,
             dimensions: (0, 0),
             cursor_location: None,
             last_event: None,
@@ -204,7 +202,9 @@ fn setup_terminal() {
 
     execute!(stdout, terminal::Clear(terminal::ClearType::All)).unwrap();
 
-    execute!(stdout, crossterm::event::EnableMouseCapture).unwrap();
+    if DEBUG_LEVEL.debug_mouse {
+        execute!(stdout, crossterm::event::EnableMouseCapture).unwrap();
+    }
 
     terminal::enable_raw_mode().unwrap();
 }
@@ -212,7 +212,9 @@ fn setup_terminal() {
 fn cleanup_terminal() {
     let mut stdout = io::stdout();
 
-    execute!(stdout, crossterm::event::DisableMouseCapture).unwrap();
+    if DEBUG_LEVEL.debug_mouse {
+        execute!(stdout, crossterm::event::DisableMouseCapture).unwrap();
+    }
 
     execute!(stdout, cursor::MoveTo(0, 0)).unwrap();
     execute!(stdout, terminal::Clear(terminal::ClearType::All)).unwrap();


### PR DESCRIPTION
Resolves #72 by employing a conditional check for the `DEBUG_MOUSE=1` env variable

*alternative to #73*