### PR TITLE
Theme: allow selective theme definitions

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -127,8 +127,8 @@ fn draw_main<B: Backend>(frame: &mut Frame<B>, app: &mut App, area: Rect) {
             frame.render_widget(
                 Tabs::new(tabs)
                     .select(app.current_tab)
-                    .style(Style::default().fg(THEME.text_secondary))
-                    .highlight_style(Style::default().fg(THEME.text_primary)),
+                    .style(Style::default().fg(THEME.text_secondary()))
+                    .highlight_style(Style::default().fg(THEME.text_primary())),
                 header[0],
             );
         }
@@ -139,7 +139,7 @@ fn draw_main<B: Backend>(frame: &mut Frame<B>, app: &mut App, area: Rect) {
                 Paragraph::new(Text::styled("Help '?'", Style::default()))
                     .style(
                         Style::default()
-                            .fg(THEME.text_normal)
+                            .fg(THEME.text_normal())
                             .bg(THEME.background()),
                     )
                     .alignment(Alignment::Center),
@@ -267,7 +267,7 @@ fn draw_summary<B: Backend>(frame: &mut Frame<B>, app: &mut App, mut area: Rect)
             Paragraph::new(Text::styled("Help '?'", Style::default()))
                 .style(
                     Style::default()
-                        .fg(THEME.text_normal)
+                        .fg(THEME.text_normal())
                         .bg(THEME.background()),
                 )
                 .alignment(Alignment::Center),
@@ -299,7 +299,7 @@ fn draw_summary<B: Backend>(frame: &mut Frame<B>, app: &mut App, mut area: Rect)
         frame.render_widget(
             Block::default().borders(Borders::TOP).border_style(
                 Style::default()
-                    .fg(THEME.border_secondary)
+                    .fg(THEME.border_secondary())
                     .bg(THEME.background()),
             ),
             layout[2],
@@ -321,8 +321,8 @@ fn draw_summary<B: Backend>(frame: &mut Frame<B>, app: &mut App, mut area: Rect)
 
         let tabs = Tabs::new(time_frames)
             .select(app.summary_time_frame.idx())
-            .style(Style::default().fg(THEME.text_secondary))
-            .highlight_style(Style::default().fg(THEME.text_primary));
+            .style(Style::default().fg(THEME.text_secondary()))
+            .highlight_style(Style::default().fg(THEME.text_primary()));
 
         frame.render_widget(tabs, bottom_layout[0]);
 
@@ -332,17 +332,17 @@ fn draw_summary<B: Backend>(frame: &mut Frame<B>, app: &mut App, mut area: Rect)
         let up_arrow = Span::styled(
             "ᐱ",
             Style::default().fg(if more_up {
-                THEME.text_normal
+                THEME.text_normal()
             } else {
-                THEME.gray
+                THEME.gray()
             }),
         );
         let down_arrow = Span::styled(
             "ᐯ",
             Style::default().fg(if more_down {
-                THEME.text_normal
+                THEME.text_normal()
             } else {
-                THEME.gray
+                THEME.gray()
             }),
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ lazy_static! {
     pub static ref TRUNC_PRE: bool = OPTS.trunc_pre;
     pub static ref SHOW_VOLUMES: RwLock<bool> = RwLock::new(OPTS.show_volumes);
     pub static ref DEFAULT_TIMESTAMPS: RwLock<HashMap<TimeFrame, Vec<i64>>> = Default::default();
-    pub static ref THEME: theme::Theme = OPTS.theme.unwrap_or_default().zip();
+    pub static ref THEME: theme::Theme = OPTS.theme.unwrap_or_default();
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ lazy_static! {
     pub static ref TRUNC_PRE: bool = OPTS.trunc_pre;
     pub static ref SHOW_VOLUMES: RwLock<bool> = RwLock::new(OPTS.show_volumes);
     pub static ref DEFAULT_TIMESTAMPS: RwLock<HashMap<TimeFrame, Vec<i64>>> = Default::default();
-    pub static ref THEME: theme::Theme = OPTS.theme.unwrap_or_default();
+    pub static ref THEME: theme::Theme = OPTS.theme.unwrap_or_default().zip();
 }
 
 fn main() {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -20,6 +20,11 @@ macro_rules! def_theme_struct_with_defaults {
                     self.$name.unwrap_or($color)
                 }
             )+
+            pub fn zip(self) -> Self {
+                Self {
+                    $( $name: self.$name.or(Some($color)), )+
+                }
+            }
         }
         impl Default for Theme {
             fn default() -> Theme {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,7 +5,7 @@ use self::de::deserialize_option_color_hex_string;
 
 macro_rules! def_theme_struct_with_defaults {
     ($($name:ident => $color:expr),+) => {
-        #[derive(Debug, Clone, Copy, Deserialize)]
+        #[derive(Clone, Copy, Deserialize)]
         pub struct Theme {
             $(
                 #[serde(deserialize_with = "deserialize_option_color_hex_string")]
@@ -20,7 +20,7 @@ macro_rules! def_theme_struct_with_defaults {
                     self.$name.unwrap_or($color)
                 }
             )+
-            pub fn zip(self) -> Self {
+            pub fn zip(&self) -> Self {
                 Self {
                     $( $name: self.$name.or(Some($color)), )+
                 }
@@ -31,6 +31,14 @@ macro_rules! def_theme_struct_with_defaults {
                 Self {
                     $( $name: Some($color), )+
                 }
+            }
+        }
+        impl std::fmt::Debug for Theme {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let me = self.zip();
+                f.debug_struct("Theme")
+                    $(.field(stringify!($name), &me.$name.ok_or(std::fmt::Error)?))+
+                    .finish()
             }
         }
     };

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,7 +5,7 @@ use self::de::deserialize_option_color_hex_string;
 
 macro_rules! def_theme_struct_with_defaults {
     ($($name:ident => $color:expr),+) => {
-        #[derive(Clone, Copy, Deserialize)]
+        #[derive(Debug, Clone, Copy, Deserialize)]
         pub struct Theme {
             $(
                 #[serde(deserialize_with = "deserialize_option_color_hex_string")]
@@ -20,25 +20,12 @@ macro_rules! def_theme_struct_with_defaults {
                     self.$name.unwrap_or($color)
                 }
             )+
-            pub fn zip(&self) -> Self {
-                Self {
-                    $( $name: self.$name.or(Some($color)), )+
-                }
-            }
         }
         impl Default for Theme {
             fn default() -> Theme {
                 Self {
                     $( $name: Some($color), )+
                 }
-            }
-        }
-        impl std::fmt::Debug for Theme {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let me = self.zip();
-                f.debug_struct("Theme")
-                    $(.field(stringify!($name), &me.$name.ok_or(std::fmt::Error)?))+
-                    .finish()
             }
         }
     };

--- a/src/widget/add_stock.rs
+++ b/src/widget/add_stock.rs
@@ -50,20 +50,22 @@ impl StatefulWidget for AddStockWidget {
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let spans = if !state.has_user_input && state.error_msg.is_some() {
             Spans::from(vec![
-                Span::styled("> ", Style::default().fg(THEME.text_normal)),
+                Span::styled("> ", Style::default().fg(THEME.text_normal())),
                 Span::styled(
                     state.error_msg.as_ref().unwrap(),
-                    Style::default().add_modifier(Modifier::BOLD).fg(THEME.loss),
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(THEME.loss()),
                 ),
             ])
         } else {
             Spans::from(vec![
-                Span::styled("> ", Style::default().fg(THEME.text_normal)),
+                Span::styled("> ", Style::default().fg(THEME.text_normal())),
                 Span::styled(
                     &state.search_string,
                     Style::default()
                         .add_modifier(Modifier::BOLD)
-                        .fg(THEME.text_secondary),
+                        .fg(THEME.text_secondary()),
                 ),
             ])
         };

--- a/src/widget/block.rs
+++ b/src/widget/block.rs
@@ -7,6 +7,6 @@ use crate::THEME;
 pub fn new(title: &str) -> Block {
     Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(THEME.border_primary))
-        .title(Span::styled(title, Style::default().fg(THEME.text_normal)))
+        .border_style(Style::default().fg(THEME.border_primary()))
+        .title(Span::styled(title, Style::default().fg(THEME.text_normal())))
 }

--- a/src/widget/block.rs
+++ b/src/widget/block.rs
@@ -8,5 +8,8 @@ pub fn new(title: &str) -> Block {
     Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(THEME.border_primary()))
-        .title(Span::styled(title, Style::default().fg(THEME.text_normal())))
+        .title(Span::styled(
+            title,
+            Style::default().fg(THEME.text_normal()),
+        ))
 }

--- a/src/widget/help.rs
+++ b/src/widget/help.rs
@@ -69,7 +69,7 @@ impl Widget for HelpWidget {
             .map(|line| {
                 Spans::from(Span::styled(
                     format!("{}\n", line),
-                    Style::default().fg(THEME.text_normal),
+                    Style::default().fg(THEME.text_normal()),
                 ))
             })
             .collect();

--- a/src/widget/options.rs
+++ b/src/widget/options.rs
@@ -269,7 +269,7 @@ impl CachableWidget<OptionsState> for OptionsWidget {
             let call_put_selector = vec![
                 Span::styled(
                     "Call",
-                    Style::default().fg(THEME.profit).add_modifier(
+                    Style::default().fg(THEME.profit()).add_modifier(
                         if state.selected_type == OptionType::Call {
                             Modifier::BOLD | Modifier::UNDERLINED
                         } else {
@@ -280,7 +280,7 @@ impl CachableWidget<OptionsState> for OptionsWidget {
                 Span::styled(" | ", Style::default()),
                 Span::styled(
                     "Put",
-                    Style::default().fg(THEME.loss).add_modifier(
+                    Style::default().fg(THEME.loss()).add_modifier(
                         if state.selected_type == OptionType::Put {
                             Modifier::BOLD | Modifier::UNDERLINED
                         } else {
@@ -294,7 +294,7 @@ impl CachableWidget<OptionsState> for OptionsWidget {
             chunks[0] = add_padding(chunks[0], 1, PaddingDirection::Right);
 
             Block::default()
-                .style(Style::default().fg(THEME.border_secondary))
+                .style(Style::default().fg(THEME.border_secondary()))
                 .borders(Borders::BOTTOM)
                 .render(chunks[0], buf);
 
@@ -303,7 +303,7 @@ impl CachableWidget<OptionsState> for OptionsWidget {
             Paragraph::new(Spans::from(call_put_selector))
                 .style(
                     Style::default()
-                        .fg(THEME.text_normal)
+                        .fg(THEME.text_normal())
                         .bg(THEME.background()),
                 )
                 .alignment(Alignment::Center)
@@ -322,7 +322,7 @@ impl CachableWidget<OptionsState> for OptionsWidget {
             selector_chunks[0] = add_padding(selector_chunks[0], 1, PaddingDirection::Left);
 
             Block::default()
-                .style(Style::default().fg(THEME.border_secondary))
+                .style(Style::default().fg(THEME.border_secondary()))
                 .borders(Borders::RIGHT)
                 .render(selector_chunks[0], buf);
             selector_chunks[0] = add_padding(selector_chunks[0], 2, PaddingDirection::Right);
@@ -342,14 +342,14 @@ impl CachableWidget<OptionsState> for OptionsWidget {
             let list = List::new(dates)
                 .style(
                     Style::default()
-                        .fg(THEME.text_normal)
+                        .fg(THEME.text_normal())
                         .bg(THEME.background()),
                 )
                 .highlight_style(Style::default().bg(
                     if state.selection_mode == SelectionMode::Dates {
-                        THEME.highlight_focused
+                        THEME.highlight_focused()
                     } else {
-                        THEME.highlight_unfocused
+                        THEME.highlight_unfocused()
                     },
                 ));
 
@@ -364,7 +364,7 @@ impl CachableWidget<OptionsState> for OptionsWidget {
 
             Paragraph::new(Span::styled(
                 "Date",
-                Style::default().fg(THEME.text_secondary),
+                Style::default().fg(THEME.text_secondary()),
             ))
             .render(selector_chunks[0], buf);
 
@@ -391,31 +391,31 @@ impl CachableWidget<OptionsState> for OptionsWidget {
                         Cell::from(format!("{: >7.2}%", d.percent_change)),
                     ])
                     .style(Style::default().fg(if d.percent_change >= 0.0 {
-                        THEME.profit
+                        THEME.profit()
                     } else {
-                        THEME.loss
+                        THEME.loss()
                     }))
                 });
 
                 let table = Table::new(rows)
                     .header(
                         Row::new(vec!["Strike", "Price", "% Change"])
-                            .style(Style::default().fg(THEME.text_secondary))
+                            .style(Style::default().fg(THEME.text_secondary()))
                             .bottom_margin(1),
                     )
                     .style(
                         Style::default()
-                            .fg(THEME.text_normal)
+                            .fg(THEME.text_normal())
                             .bg(THEME.background()),
                     )
                     .highlight_style(
                         Style::default()
                             .bg(if state.selection_mode == SelectionMode::Options {
-                                THEME.highlight_focused
+                                THEME.highlight_focused()
                             } else {
-                                THEME.highlight_unfocused
+                                THEME.highlight_unfocused()
                             })
-                            .fg(THEME.text_normal),
+                            .fg(THEME.text_normal()),
                     )
                     .widths(&[
                         Constraint::Length(8),
@@ -441,7 +441,7 @@ impl CachableWidget<OptionsState> for OptionsWidget {
             chunks[1] = add_padding(chunks[1], 1, PaddingDirection::Right);
 
             Block::default()
-                .style(Style::default().fg(THEME.border_secondary))
+                .style(Style::default().fg(THEME.border_secondary()))
                 .borders(Borders::BOTTOM)
                 .render(chunks[1], buf);
 
@@ -547,14 +547,14 @@ impl CachableWidget<OptionsState> for OptionsWidget {
                     Paragraph::new(column_0)
                         .style(
                             Style::default()
-                                .fg(THEME.text_normal)
+                                .fg(THEME.text_normal())
                                 .bg(THEME.background()),
                         )
                         .render(columns[0], buf);
                     Paragraph::new(column_1)
                         .style(
                             Style::default()
-                                .fg(THEME.text_normal)
+                                .fg(THEME.text_normal())
                                 .bg(THEME.background()),
                         )
                         .render(columns[1], buf);

--- a/src/widget/stock.rs
+++ b/src/widget/stock.rs
@@ -439,7 +439,7 @@ impl StockState {
                 labels.push(chunk.get(0).map_or(Span::raw("".to_string()), |d| {
                     Span::styled(
                         self.time_frame.format_time(*d),
-                        Style::default().fg(THEME.text_normal),
+                        Style::default().fg(THEME.text_normal()),
                     )
                 }));
             }
@@ -450,7 +450,7 @@ impl StockState {
                     .map_or(Span::raw("".to_string()), |d| {
                         Span::styled(
                             self.time_frame.format_time(*d),
-                            Style::default().fg(THEME.text_normal),
+                            Style::default().fg(THEME.text_normal()),
                         )
                     }),
             );
@@ -468,15 +468,15 @@ impl StockState {
             vec![
                 Span::styled(
                     format!("{:>8.2}", (min - 0.05)),
-                    Style::default().fg(THEME.text_normal),
+                    Style::default().fg(THEME.text_normal()),
                 ),
                 Span::styled(
                     format!("{:>8.2}", ((min - 0.05) + (max + 0.05)) / 2.0),
-                    Style::default().fg(THEME.text_normal),
+                    Style::default().fg(THEME.text_normal()),
                 ),
                 Span::styled(
                     format!("{:>8.2}", max + 0.05),
-                    Style::default().fg(THEME.text_normal),
+                    Style::default().fg(THEME.text_normal()),
                 ),
             ]
         } else {
@@ -629,7 +629,7 @@ impl CachableWidget<StockState> for StockWidget {
                         },
                         Style::default()
                             .add_modifier(Modifier::BOLD)
-                            .fg(THEME.text_primary),
+                            .fg(THEME.text_primary()),
                     ),
                     Span::styled(
                         if loaded {
@@ -640,9 +640,9 @@ impl CachableWidget<StockState> for StockWidget {
                         Style::default()
                             .add_modifier(Modifier::BOLD)
                             .fg(if pct_change >= 0.0 {
-                                THEME.profit
+                                THEME.profit()
                             } else {
-                                THEME.loss
+                                THEME.loss()
                             }),
                     ),
                 ]),
@@ -654,7 +654,7 @@ impl CachableWidget<StockState> for StockWidget {
                         } else {
                             "".to_string()
                         },
-                        Style::default().fg(THEME.text_secondary),
+                        Style::default().fg(THEME.text_secondary()),
                     ),
                 ]),
                 Spans::from(vec![
@@ -665,7 +665,7 @@ impl CachableWidget<StockState> for StockWidget {
                         } else {
                             "".to_string()
                         },
-                        Style::default().fg(THEME.text_secondary),
+                        Style::default().fg(THEME.text_secondary()),
                     ),
                 ]),
                 Spans::default(),
@@ -673,7 +673,7 @@ impl CachableWidget<StockState> for StockWidget {
                     Span::styled("v: ", Style::default()),
                     Span::styled(
                         if loaded { vol } else { "".to_string() },
-                        Style::default().fg(THEME.text_secondary),
+                        Style::default().fg(THEME.text_secondary()),
                     ),
                 ]),
             ];
@@ -681,7 +681,7 @@ impl CachableWidget<StockState> for StockWidget {
             Paragraph::new(company_info)
                 .style(
                     Style::default()
-                        .fg(THEME.text_normal)
+                        .fg(THEME.text_normal())
                         .bg(THEME.background()),
                 )
                 .alignment(Alignment::Left)
@@ -703,7 +703,7 @@ impl CachableWidget<StockState> for StockWidget {
                     toggle_info.push(Spans::from(Span::styled(
                         "Volumes  'v'",
                         Style::default().bg(if show_volumes {
-                            THEME.highlight_unfocused
+                            THEME.highlight_unfocused()
                         } else {
                             THEME.background()
                         }),
@@ -712,7 +712,7 @@ impl CachableWidget<StockState> for StockWidget {
                     toggle_info.push(Spans::from(Span::styled(
                         "X Labels 'x'",
                         Style::default().bg(if show_x_labels {
-                            THEME.highlight_unfocused
+                            THEME.highlight_unfocused()
                         } else {
                             THEME.background()
                         }),
@@ -721,7 +721,7 @@ impl CachableWidget<StockState> for StockWidget {
                     toggle_info.push(Spans::from(Span::styled(
                         "Pre Post 'p'",
                         Style::default().bg(if enable_pre_post {
-                            THEME.highlight_unfocused
+                            THEME.highlight_unfocused()
                         } else {
                             THEME.background()
                         }),
@@ -732,7 +732,7 @@ impl CachableWidget<StockState> for StockWidget {
                     toggle_info.push(Spans::from(Span::styled(
                         "Options  'o'",
                         Style::default().bg(if state.show_options {
-                            THEME.highlight_unfocused
+                            THEME.highlight_unfocused()
                         } else {
                             THEME.background()
                         }),
@@ -742,7 +742,7 @@ impl CachableWidget<StockState> for StockWidget {
                 Paragraph::new(toggle_info)
                     .style(
                         Style::default()
-                            .fg(THEME.text_normal)
+                            .fg(THEME.text_normal())
                             .bg(THEME.background()),
                     )
                     .alignment(Alignment::Left)
@@ -872,11 +872,11 @@ impl CachableWidget<StockState> for StockWidget {
                     Style::default()
                         .fg(
                             if trading_period != TradingPeriod::Regular && enable_pre_post {
-                                THEME.gray
+                                THEME.gray()
                             } else if pct_change >= 0.0 {
-                                THEME.profit
+                                THEME.profit()
                             } else {
-                                THEME.loss
+                                THEME.loss()
                             },
                         )
                         .bg(THEME.background()),
@@ -891,11 +891,11 @@ impl CachableWidget<StockState> for StockWidget {
                         .style(
                             Style::default()
                                 .fg(if trading_period != TradingPeriod::Post {
-                                    THEME.gray
+                                    THEME.gray()
                                 } else if pct_change >= 0.0 {
-                                    THEME.profit
+                                    THEME.profit()
                                 } else {
-                                    THEME.loss
+                                    THEME.loss()
                                 })
                                 .bg(THEME.background()),
                         )
@@ -912,11 +912,11 @@ impl CachableWidget<StockState> for StockWidget {
                         .style(
                             Style::default()
                                 .fg(if trading_period != TradingPeriod::Pre {
-                                    THEME.gray
+                                    THEME.gray()
                                 } else if pct_change >= 0.0 {
-                                    THEME.profit
+                                    THEME.profit()
                                 } else {
-                                    THEME.loss
+                                    THEME.loss()
                                 })
                                 .bg(THEME.background()),
                         )
@@ -930,7 +930,7 @@ impl CachableWidget<StockState> for StockWidget {
                     0,
                     Dataset::default()
                         .marker(Marker::Braille)
-                        .style(Style::default().fg(THEME.gray).bg(THEME.background()))
+                        .style(Style::default().fg(THEME.gray()).bg(THEME.background()))
                         .graph_type(GraphType::Line)
                         .data(&data),
                 );
@@ -986,7 +986,7 @@ impl CachableWidget<StockState> for StockWidget {
 
                     Block::default()
                         .borders(Borders::LEFT)
-                        .border_style(Style::default().fg(THEME.border_axis))
+                        .border_style(Style::default().fg(THEME.border_axis()))
                         .render(volume_chunks, buf);
 
                     volume_chunks.x += 1;
@@ -994,7 +994,7 @@ impl CachableWidget<StockState> for StockWidget {
                     BarChart::default()
                         .bar_gap(0)
                         .bar_set(bar::NINE_LEVELS)
-                        .style(Style::default().fg(THEME.gray).bg(THEME.background()))
+                        .style(Style::default().fg(THEME.gray()).bg(THEME.background()))
                         .data(&volumes)
                         .render(volume_chunks, buf);
                 }
@@ -1004,7 +1004,7 @@ impl CachableWidget<StockState> for StockWidget {
                 .style(Style::default().bg(THEME.background()))
                 .block(
                     Block::default()
-                        .style(Style::default().fg(THEME.border_secondary))
+                        .style(Style::default().fg(THEME.border_secondary()))
                         .borders(Borders::TOP)
                         .border_style(Style::default()),
                 )
@@ -1013,7 +1013,7 @@ impl CachableWidget<StockState> for StockWidget {
 
                     if show_x_labels && loaded {
                         axis.labels(x_labels)
-                            .style(Style::default().fg(THEME.border_axis))
+                            .style(Style::default().fg(THEME.border_axis()))
                     } else {
                         axis
                     }
@@ -1022,7 +1022,7 @@ impl CachableWidget<StockState> for StockWidget {
                     Axis::default()
                         .bounds(state.y_bounds(min, max))
                         .labels(state.y_labels(min, max))
-                        .style(Style::default().fg(THEME.border_axis)),
+                        .style(Style::default().fg(THEME.border_axis())),
                 )
                 .render(graph_chunks[0], buf);
         }
@@ -1038,13 +1038,13 @@ impl CachableWidget<StockState> for StockWidget {
                 .block(
                     Block::default().borders(Borders::TOP).border_style(
                         Style::default()
-                            .fg(THEME.border_secondary)
+                            .fg(THEME.border_secondary())
                             .bg(THEME.background()),
                     ),
                 )
                 .select(state.time_frame.idx())
-                .style(Style::default().fg(THEME.text_secondary))
-                .highlight_style(Style::default().fg(THEME.text_primary))
+                .style(Style::default().fg(THEME.text_secondary()))
+                .highlight_style(Style::default().fg(THEME.text_primary()))
                 .render(chunks[2], buf);
         }
     }

--- a/src/widget/stock_summary.rs
+++ b/src/widget/stock_summary.rs
@@ -68,12 +68,12 @@ impl CachableWidget<StockState> for StockSummaryWidget {
                         format!("{:<4}", loading_indicator)
                     }
                 ),
-                Style::default().fg(THEME.text_normal),
+                Style::default().fg(THEME.text_normal()),
             ))
             .borders(Borders::TOP)
             .border_style(
                 Style::default()
-                    .fg(THEME.border_secondary)
+                    .fg(THEME.border_secondary())
                     .bg(THEME.background()),
             )
             .render(area, buf);
@@ -93,7 +93,7 @@ impl CachableWidget<StockState> for StockSummaryWidget {
 
             let prices = vec![
                 Spans::from(vec![
-                    Span::styled("c: ", Style::default().fg(THEME.text_normal)),
+                    Span::styled("c: ", Style::default().fg(THEME.text_normal())),
                     Span::styled(
                         if loaded {
                             format!("{:.2} {}", state.current_price(), currency)
@@ -102,37 +102,37 @@ impl CachableWidget<StockState> for StockSummaryWidget {
                         },
                         Style::default()
                             .add_modifier(Modifier::BOLD)
-                            .fg(THEME.text_primary),
+                            .fg(THEME.text_primary()),
                     ),
                 ]),
                 Spans::from(vec![
-                    Span::styled("h: ", Style::default().fg(THEME.text_normal)),
+                    Span::styled("h: ", Style::default().fg(THEME.text_normal())),
                     Span::styled(
                         if loaded {
                             format!("{:.2}", high)
                         } else {
                             "".to_string()
                         },
-                        Style::default().fg(THEME.text_secondary),
+                        Style::default().fg(THEME.text_secondary()),
                     ),
                 ]),
                 Spans::from(vec![
-                    Span::styled("l: ", Style::default().fg(THEME.text_normal)),
+                    Span::styled("l: ", Style::default().fg(THEME.text_normal())),
                     Span::styled(
                         if loaded {
                             format!("{:.2}", low)
                         } else {
                             "".to_string()
                         },
-                        Style::default().fg(THEME.text_secondary),
+                        Style::default().fg(THEME.text_secondary()),
                     ),
                 ]),
                 Spans::default(),
                 Spans::from(vec![
-                    Span::styled("v: ", Style::default().fg(THEME.text_normal)),
+                    Span::styled("v: ", Style::default().fg(THEME.text_normal())),
                     Span::styled(
                         if loaded { vol } else { "".to_string() },
-                        Style::default().fg(THEME.text_secondary),
+                        Style::default().fg(THEME.text_secondary()),
                     ),
                 ]),
             ];
@@ -146,9 +146,9 @@ impl CachableWidget<StockState> for StockSummaryWidget {
                 Style::default()
                     .add_modifier(Modifier::BOLD)
                     .fg(if pct_change >= 0.0 {
-                        THEME.profit
+                        THEME.profit()
                     } else {
-                        THEME.loss
+                        THEME.loss()
                     }),
             )];
 
@@ -279,11 +279,11 @@ impl CachableWidget<StockState> for StockSummaryWidget {
                 .marker(Marker::Braille)
                 .style(Style::default().fg(
                     if trading_period != TradingPeriod::Regular && enable_pre_post {
-                        THEME.gray
+                        THEME.gray()
                     } else if pct_change >= 0.0 {
-                        THEME.profit
+                        THEME.profit()
                     } else {
-                        THEME.loss
+                        THEME.loss()
                     },
                 ))
                 .graph_type(graph_type)
@@ -295,11 +295,11 @@ impl CachableWidget<StockState> for StockSummaryWidget {
                         .marker(Marker::Braille)
                         .style(
                             Style::default().fg(if trading_period != TradingPeriod::Post {
-                                THEME.gray
+                                THEME.gray()
                             } else if pct_change >= 0.0 {
-                                THEME.profit
+                                THEME.profit()
                             } else {
-                                THEME.loss
+                                THEME.loss()
                             }),
                         )
                         .graph_type(GraphType::Line)
@@ -314,11 +314,11 @@ impl CachableWidget<StockState> for StockSummaryWidget {
                         .marker(Marker::Braille)
                         .style(
                             Style::default().fg(if trading_period != TradingPeriod::Pre {
-                                THEME.gray
+                                THEME.gray()
                             } else if pct_change >= 0.0 {
-                                THEME.profit
+                                THEME.profit()
                             } else {
-                                THEME.loss
+                                THEME.loss()
                             }),
                         )
                         .graph_type(GraphType::Line)
@@ -331,7 +331,7 @@ impl CachableWidget<StockState> for StockSummaryWidget {
                     0,
                     Dataset::default()
                         .marker(Marker::Braille)
-                        .style(Style::default().fg(THEME.gray))
+                        .style(Style::default().fg(THEME.gray()))
                         .graph_type(GraphType::Line)
                         .data(&data),
                 );
@@ -377,7 +377,7 @@ impl CachableWidget<StockState> for StockSummaryWidget {
 
                         Block::default()
                             .borders(Borders::LEFT)
-                            .border_style(Style::default().fg(THEME.border_axis))
+                            .border_style(Style::default().fg(THEME.border_axis()))
                             .render(volume_chunks, buf);
 
                         volume_chunks.x += 1;
@@ -385,7 +385,7 @@ impl CachableWidget<StockState> for StockSummaryWidget {
                         BarChart::default()
                             .bar_gap(0)
                             .bar_set(bar::NINE_LEVELS)
-                            .style(Style::default().fg(THEME.gray))
+                            .style(Style::default().fg(THEME.gray()))
                             .data(&volumes)
                             .render(volume_chunks, buf);
                     }
@@ -400,7 +400,7 @@ impl CachableWidget<StockState> for StockSummaryWidget {
                     Axis::default()
                         .bounds(state.y_bounds(min, max))
                         .labels(state.y_labels(min, max))
-                        .style(Style::default().fg(THEME.border_axis)),
+                        .style(Style::default().fg(THEME.border_axis())),
                 )
                 .render(graph_chunks[0], buf);
         }


### PR DESCRIPTION
Currently *(2c4bbfa)*, it's all or nothing when it comes to theming, except with `config.themes.background`.

This PR extends that selective defaulting to all the options.

This also zips the outputs, ensuring there's always a `Color` for every entry (useful for `Debug`).

In summary, it lets you change the color for that one thing without needing to set colors for all things.