### PR TITLE
Theme: conditionally include theme in the debug view

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -41,6 +41,7 @@ impl App {
 pub struct EnvConfig {
     pub show_debug: bool,
     pub debug_mouse: bool,
+    pub debug_theme: bool,
 }
 
 impl EnvConfig {
@@ -53,6 +54,7 @@ impl EnvConfig {
         Self {
             show_debug: Self::env_match("SHOW_DEBUG", "0", "1"),
             debug_mouse: Self::env_match("DEBUG_MOUSE", "0", "1"),
+            debug_theme: Self::env_match("DEBUG_THEME", "0", "1"),
         }
     }
 }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -10,7 +10,7 @@ use crate::common::TimeFrame;
 use crate::widget::{
     block, AddStockWidget, OptionsWidget, StockSummaryWidget, StockWidget, HELP_HEIGHT, HELP_WIDTH,
 };
-use crate::{SHOW_VOLUMES, THEME};
+use crate::{DEBUG_LEVEL, SHOW_VOLUMES, THEME};
 
 pub fn draw<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) {
     let current_size = terminal.size().unwrap_or_default();
@@ -374,7 +374,18 @@ fn draw_help<B: Backend>(frame: &mut Frame<B>, app: &mut App, area: Rect) {
 fn draw_debug<B: Backend>(frame: &mut Frame<B>, app: &mut App, area: Rect) {
     app.debug.mode = app.mode;
 
-    let debug_text = Text::styled(format!("{:?}", app.debug), Style::default());
+    let debug_text = Text::styled(
+        format!(
+            "> {:?}{}",
+            app.debug,
+            if DEBUG_LEVEL.debug_theme {
+                format!("\n> {:?}", *THEME)
+            } else {
+                "".to_string()
+            }
+        ),
+        Style::default(),
+    );
     let debug_paragraph = Paragraph::new(debug_text).wrap(Wrap { trim: true });
 
     frame.render_widget(debug_paragraph, area);


### PR DESCRIPTION
Use the `DEBUG_THEME=1` env to include theme information within the Debug widget

`$ SHOW_DEBUG=1 DEBUG_THEME=1 tickrs`

```rust
> DebugInfo { enabled: true, dimensions: (168, 42), cursor_location: None, last_event: None, mode: DisplaySummary }
> Theme { background: Reset, gray: DarkGray, profit: Green, loss: Red, text_normal: Reset, text_primary: Yellow, text_secondary: Cyan, border_primary: Blue,
border_secondary: Reset, border_axis: Blue, highlight_focused: Yellow, highlight_unfocused: DarkGray }
```