### PR TITLE
Compiler optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ description = "Realtime ticker data in your terminal 📈"
 keywords = ["tui","terminal","stocks"]
 categories = ["command-line-utilities"]
 
+[profile.release]
+lto = true
+
 [workspace]
 members = [
     ".",

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -4,6 +4,7 @@ use tui::style::{Color, Style};
 use self::de::deserialize_option_color_hex_string;
 use crate::THEME;
 
+#[inline]
 pub fn style() -> Style {
     Style::default().bg(THEME.background())
 }


### PR DESCRIPTION
@miraclx LTO appears to reduce binary size from 11MB to 7.8MB on Linux. No noticeable difference on the inlined function, but maybe it was already getting inlined or is immaterial. 