### PR TITLE
unify generic keybindings across panes

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -2,400 +2,288 @@ use app::ScrollDirection;
 use crossbeam_channel::Sender;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+use crate::app::{self, Mode};
 use crate::widget::options;
-use crate::{app, cleanup_terminal, CHART_TYPE, ENABLE_PRE_POST, SHOW_VOLUMES, SHOW_X_LABELS};
+use crate::{cleanup_terminal, CHART_TYPE, ENABLE_PRE_POST, SHOW_VOLUMES, SHOW_X_LABELS};
 
-pub fn handle_keys_display_stock(
-    key_event: KeyEvent,
-    mut app: &mut app::App,
-    request_redraw: &Sender<()>,
-) {
-    if key_event.modifiers.is_empty() {
-        match key_event.code {
-            KeyCode::Left => {
-                app.stocks[app.current_tab].time_frame_down();
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Right => {
-                app.stocks[app.current_tab].time_frame_up();
+fn handle_keys_add_stock_(keycode: KeyCode, mut app: &mut app::App) {
+    match keycode {
+        KeyCode::Enter => {
+            let mut stock = app.add_stock.enter();
 
-                let _ = request_redraw.try_send(());
+            if app.previous_mode == app::Mode::DisplaySummary {
+                stock.set_time_frame(app.summary_time_frame);
             }
-            KeyCode::Char('/') => {
-                app.previous_mode = app.mode;
-                app.mode = app::Mode::AddStock;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('c') => {
-                let mut chart_type = CHART_TYPE.write().unwrap();
-                *chart_type = chart_type.toggle();
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('k') => {
-                app.stocks.remove(app.current_tab);
 
-                if app.current_tab != 0 {
-                    app.current_tab -= 1;
-                }
+            app.stocks.push(stock);
+            app.current_tab = app.stocks.len() - 1;
 
-                if app.stocks.is_empty() {
-                    app.previous_mode = app.mode;
-                    app.mode = app::Mode::AddStock;
-                }
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('p') => {
-                let mut guard = ENABLE_PRE_POST.write().unwrap();
-                *guard = !*guard;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('q') => {
-                cleanup_terminal();
-                std::process::exit(0);
-            }
-            KeyCode::Char('s') => {
-                app.mode = app::Mode::DisplaySummary;
-
-                for stock in app.stocks.iter_mut() {
-                    if stock.time_frame != app.summary_time_frame {
-                        stock.set_time_frame(app.summary_time_frame);
-                    }
-                }
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('?') => {
-                app.previous_mode = app.mode;
-                app.mode = app::Mode::Help;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('o') => {
-                if app.stocks[app.current_tab].toggle_options() {
-                    app.mode = app::Mode::DisplayOptions;
-                    let _ = request_redraw.try_send(());
-                }
-            }
-            KeyCode::Char('x') => {
-                let mut show_x_labels = SHOW_X_LABELS.write().unwrap();
-                *show_x_labels = !*show_x_labels;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('v') => {
-                let mut show_volumes = SHOW_VOLUMES.write().unwrap();
-                *show_volumes = !*show_volumes;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Tab => {
-                if app.current_tab == app.stocks.len() - 1 {
-                    app.current_tab = 0;
-                } else {
-                    app.current_tab += 1;
-                }
-                let _ = request_redraw.try_send(());
-            }
-            _ => {}
+            app.add_stock.reset();
+            app.mode = app.previous_mode;
         }
-    } else if key_event.modifiers == KeyModifiers::CONTROL {
-        match key_event.code {
-            KeyCode::Left => {
-                let new_idx = if app.current_tab == 0 {
-                    app.stocks.len() - 1
-                } else {
-                    app.current_tab - 1
-                };
-                app.stocks.swap(app.current_tab, new_idx);
-                app.current_tab = new_idx;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Right => {
-                let new_idx = (app.current_tab + 1) % app.stocks.len();
-                app.stocks.swap(app.current_tab, new_idx);
-                app.current_tab = new_idx;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('c') => {
-                cleanup_terminal();
-                std::process::exit(0);
-            }
-            _ => {}
+        KeyCode::Char(c) => {
+            app.add_stock.add_char(c);
         }
-    } else if key_event.modifiers == KeyModifiers::SHIFT {
-        match key_event.code {
-            KeyCode::Char('?') => {
-                app.previous_mode = app.mode;
-                app.mode = app::Mode::Help;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::BackTab => {
-                if app.current_tab == 0 {
-                    app.current_tab = app.stocks.len() - 1;
-                } else {
-                    app.current_tab -= 1;
-                }
-                let _ = request_redraw.try_send(());
-            }
-            _ => {}
+        KeyCode::Backspace => {
+            app.add_stock.del_char();
         }
-    }
-}
-
-pub fn handle_keys_add_stock(
-    key_event: KeyEvent,
-    mut app: &mut app::App,
-    request_redraw: &Sender<()>,
-) {
-    if key_event.modifiers.is_empty() || key_event.modifiers == KeyModifiers::SHIFT {
-        match key_event.code {
-            KeyCode::Enter => {
-                let mut stock = app.add_stock.enter();
-
-                if app.previous_mode == app::Mode::DisplaySummary {
-                    stock.set_time_frame(app.summary_time_frame);
-                }
-
-                app.stocks.push(stock);
-                app.current_tab = app.stocks.len() - 1;
-
-                app.add_stock.reset();
+        KeyCode::Esc => {
+            app.add_stock.reset();
+            if !app.stocks.is_empty() {
                 app.mode = app.previous_mode;
-                let _ = request_redraw.try_send(());
             }
-            KeyCode::Char(c) => {
-                app.add_stock.add_char(c);
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Backspace => {
-                app.add_stock.del_char();
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Esc => {
-                app.add_stock.reset();
-                if !app.stocks.is_empty() {
-                    app.mode = app.previous_mode;
-                }
-                let _ = request_redraw.try_send(());
-            }
-            _ => {}
         }
-    } else if key_event.modifiers == KeyModifiers::CONTROL {
-        if let KeyCode::Char('c') = key_event.code {
-            cleanup_terminal();
-            std::process::exit(0);
-        }
+        _ => {}
     }
 }
 
-pub fn handle_keys_display_summary(
-    key_event: KeyEvent,
-    mut app: &mut app::App,
-    request_redraw: &Sender<()>,
-) {
-    if key_event.modifiers.is_empty() {
-        match key_event.code {
-            KeyCode::Left => {
-                app.summary_time_frame = app.summary_time_frame.down();
-
-                for stock in app.stocks.iter_mut() {
-                    stock.set_time_frame(app.summary_time_frame);
-                }
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Right => {
-                app.summary_time_frame = app.summary_time_frame.up();
-
-                for stock in app.stocks.iter_mut() {
-                    stock.set_time_frame(app.summary_time_frame);
-                }
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Up => {
-                app.summary_scroll_state.queued_scroll = Some(ScrollDirection::Up);
-
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Down => {
-                app.summary_scroll_state.queued_scroll = Some(ScrollDirection::Down);
-
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('c') => {
-                let mut chart_type = CHART_TYPE.write().unwrap();
-                *chart_type = chart_type.toggle();
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('p') => {
-                let mut guard = ENABLE_PRE_POST.write().unwrap();
-                *guard = !*guard;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('q') => {
-                cleanup_terminal();
-                std::process::exit(0);
-            }
-            KeyCode::Char('s') => {
-                app.mode = app::Mode::DisplayStock;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('v') => {
-                let mut show_volumes = SHOW_VOLUMES.write().unwrap();
-                *show_volumes = !*show_volumes;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('?') => {
-                app.previous_mode = app.mode;
-                app.mode = app::Mode::Help;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('/') => {
-                app.previous_mode = app.mode;
-                app.mode = app::Mode::AddStock;
-                let _ = request_redraw.try_send(());
-            }
-            _ => {}
+fn handle_keys_display_stock_(keycode: KeyCode, modifiers: KeyModifiers, mut app: &mut app::App) {
+    match (keycode, modifiers) {
+        (KeyCode::Left, KeyModifiers::CONTROL) => {
+            let new_idx = if app.current_tab == 0 {
+                app.stocks.len() - 1
+            } else {
+                app.current_tab - 1
+            };
+            app.stocks.swap(app.current_tab, new_idx);
+            app.current_tab = new_idx;
         }
-    } else if key_event.modifiers == KeyModifiers::CONTROL {
-        if let KeyCode::Char('c') = key_event.code {
-            cleanup_terminal();
-            std::process::exit(0);
+        (KeyCode::Right, KeyModifiers::CONTROL) => {
+            let new_idx = (app.current_tab + 1) % app.stocks.len();
+            app.stocks.swap(app.current_tab, new_idx);
+            app.current_tab = new_idx;
         }
-    } else if key_event.modifiers == KeyModifiers::SHIFT {
-        if let KeyCode::Char('?') = key_event.code {
+        (KeyCode::Left, _) => {
+            app.stocks[app.current_tab].time_frame_down();
+        }
+        (KeyCode::Right, _) => {
+            app.stocks[app.current_tab].time_frame_up();
+        }
+        (KeyCode::Char('/'), _) => {
             app.previous_mode = app.mode;
-            app.mode = app::Mode::Help;
-            let _ = request_redraw.try_send(());
+            app.mode = app::Mode::AddStock;
         }
+        (KeyCode::Char('k'), _) => {
+            app.stocks.remove(app.current_tab);
+
+            if app.current_tab != 0 {
+                app.current_tab -= 1;
+            }
+
+            if app.stocks.is_empty() {
+                app.previous_mode = app.mode;
+                app.mode = app::Mode::AddStock;
+            }
+        }
+        (KeyCode::Char('s'), _) => {
+            app.mode = app::Mode::DisplaySummary;
+
+            for stock in app.stocks.iter_mut() {
+                if stock.time_frame != app.summary_time_frame {
+                    stock.set_time_frame(app.summary_time_frame);
+                }
+            }
+        }
+        (KeyCode::Char('o'), _) => {
+            if app.stocks[app.current_tab].toggle_options() {
+                app.mode = app::Mode::DisplayOptions;
+            }
+        }
+        (KeyCode::Tab, _) => {
+            if app.current_tab == app.stocks.len() - 1 {
+                app.current_tab = 0;
+            } else {
+                app.current_tab += 1;
+            }
+        }
+        (KeyCode::BackTab, KeyModifiers::SHIFT) => {
+            if app.current_tab == 0 {
+                app.current_tab = app.stocks.len() - 1;
+            } else {
+                app.current_tab -= 1;
+            }
+        }
+        _ => {}
     }
 }
 
-pub fn handle_keys_help(key_event: KeyEvent, mut app: &mut app::App, request_redraw: &Sender<()>) {
-    if key_event.modifiers.is_empty() {
-        match key_event.code {
-            KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q') => {
-                app.mode = app.previous_mode;
-                let _ = request_redraw.try_send(());
+fn handle_keys_display_summary_(keycode: KeyCode, mut app: &mut app::App) {
+    match keycode {
+        KeyCode::Left => {
+            app.summary_time_frame = app.summary_time_frame.down();
+
+            for stock in app.stocks.iter_mut() {
+                stock.set_time_frame(app.summary_time_frame);
             }
-            _ => {}
         }
-    } else if key_event.modifiers == KeyModifiers::CONTROL {
-        if let KeyCode::Char('c') = key_event.code {
-            cleanup_terminal();
-            std::process::exit(0);
+        KeyCode::Right => {
+            app.summary_time_frame = app.summary_time_frame.up();
+
+            for stock in app.stocks.iter_mut() {
+                stock.set_time_frame(app.summary_time_frame);
+            }
         }
+        KeyCode::Up => {
+            app.summary_scroll_state.queued_scroll = Some(ScrollDirection::Up);
+        }
+        KeyCode::Down => {
+            app.summary_scroll_state.queued_scroll = Some(ScrollDirection::Down);
+        }
+        KeyCode::Char('s') => {
+            app.mode = app::Mode::DisplayStock;
+        }
+        KeyCode::Char('/') => {
+            app.previous_mode = app.mode;
+            app.mode = app::Mode::AddStock;
+        }
+        _ => {}
     }
 }
 
-pub fn handle_keys_display_options(
-    key_event: KeyEvent,
-    mut app: &mut app::App,
-    request_redraw: &Sender<()>,
-) {
-    if key_event.modifiers.is_empty() {
-        match key_event.code {
-            KeyCode::Esc | KeyCode::Char('o') => {
-                app.stocks[app.current_tab].toggle_options();
-                app.mode = app::Mode::DisplayStock;
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Char('q') => {
-                cleanup_terminal();
-                std::process::exit(0);
-            }
-            KeyCode::Tab => {
-                app.stocks[app.current_tab]
-                    .options
-                    .as_mut()
-                    .unwrap()
-                    .toggle_option_type();
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Up => {
-                match app.stocks[app.current_tab]
-                    .options
-                    .as_mut()
-                    .unwrap()
-                    .selection_mode
-                {
-                    options::SelectionMode::Dates => {
-                        app.stocks[app.current_tab]
-                            .options
-                            .as_mut()
-                            .unwrap()
-                            .previous_date();
-                    }
-                    options::SelectionMode::Options => {
-                        app.stocks[app.current_tab]
-                            .options
-                            .as_mut()
-                            .unwrap()
-                            .previous_option();
-                    }
-                }
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Down => {
-                match app.stocks[app.current_tab]
-                    .options
-                    .as_mut()
-                    .unwrap()
-                    .selection_mode
-                {
-                    options::SelectionMode::Dates => {
-                        app.stocks[app.current_tab]
-                            .options
-                            .as_mut()
-                            .unwrap()
-                            .next_date();
-                    }
-                    options::SelectionMode::Options => {
-                        app.stocks[app.current_tab]
-                            .options
-                            .as_mut()
-                            .unwrap()
-                            .next_option();
-                    }
-                }
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Left => {
-                app.stocks[app.current_tab]
-                    .options
-                    .as_mut()
-                    .unwrap()
-                    .selection_mode_left();
-                let _ = request_redraw.try_send(());
-            }
-            KeyCode::Right => {
-                if app.stocks[app.current_tab]
-                    .options
-                    .as_mut()
-                    .unwrap()
-                    .data()
-                    .is_some()
-                {
+fn handle_keys_display_options_(keycode: KeyCode, mut app: &mut app::App) {
+    match keycode {
+        KeyCode::Esc | KeyCode::Char('o') => {
+            app.stocks[app.current_tab].toggle_options();
+            app.mode = app::Mode::DisplayStock;
+        }
+        KeyCode::Tab => {
+            app.stocks[app.current_tab]
+                .options
+                .as_mut()
+                .unwrap()
+                .toggle_option_type();
+        }
+        KeyCode::Up => {
+            match app.stocks[app.current_tab]
+                .options
+                .as_mut()
+                .unwrap()
+                .selection_mode
+            {
+                options::SelectionMode::Dates => {
                     app.stocks[app.current_tab]
                         .options
                         .as_mut()
                         .unwrap()
-                        .selection_mode_right();
-                    let _ = request_redraw.try_send(());
+                        .previous_date();
+                }
+                options::SelectionMode::Options => {
+                    app.stocks[app.current_tab]
+                        .options
+                        .as_mut()
+                        .unwrap()
+                        .previous_option();
                 }
             }
-            KeyCode::Char('?') => {
-                app.previous_mode = app.mode;
-                app.mode = app::Mode::Help;
-                let _ = request_redraw.try_send(());
-            }
-            _ => {}
         }
-    } else if key_event.modifiers == KeyModifiers::CONTROL {
-        if let KeyCode::Char('c') = key_event.code {
+        KeyCode::Down => {
+            match app.stocks[app.current_tab]
+                .options
+                .as_mut()
+                .unwrap()
+                .selection_mode
+            {
+                options::SelectionMode::Dates => {
+                    app.stocks[app.current_tab]
+                        .options
+                        .as_mut()
+                        .unwrap()
+                        .next_date();
+                }
+                options::SelectionMode::Options => {
+                    app.stocks[app.current_tab]
+                        .options
+                        .as_mut()
+                        .unwrap()
+                        .next_option();
+                }
+            }
+        }
+        KeyCode::Left => {
+            app.stocks[app.current_tab]
+                .options
+                .as_mut()
+                .unwrap()
+                .selection_mode_left();
+        }
+        KeyCode::Right => {
+            if app.stocks[app.current_tab]
+                .options
+                .as_mut()
+                .unwrap()
+                .data()
+                .is_some()
+            {
+                app.stocks[app.current_tab]
+                    .options
+                    .as_mut()
+                    .unwrap()
+                    .selection_mode_right();
+            }
+        }
+        _ => {}
+    }
+}
+
+pub fn handle_key_bindings(
+    mode: Mode,
+    key_event: KeyEvent,
+    mut app: &mut app::App,
+    request_redraw: &Sender<()>,
+) {
+    match (mode, key_event.modifiers, key_event.code) {
+        (_, KeyModifiers::CONTROL, KeyCode::Char('c')) => {
             cleanup_terminal();
             std::process::exit(0);
         }
-    } else if key_event.modifiers == KeyModifiers::SHIFT {
-        if let KeyCode::Char('?') = key_event.code {
+        (Mode::AddStock, modifiers, keycode)
+            if modifiers.is_empty() || modifiers == KeyModifiers::SHIFT =>
+        {
+            handle_keys_add_stock_(keycode, app)
+        }
+        (Mode::Help, modifiers, keycode)
+            if modifiers.is_empty()
+                && (match keycode {
+                    KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q') => true,
+                    _ => false,
+                }) =>
+        {
+            app.mode = app.previous_mode;
+        }
+        (.., KeyCode::Char('q')) => {
+            cleanup_terminal();
+            std::process::exit(0);
+        }
+        (.., KeyCode::Char('?')) => {
             app.previous_mode = app.mode;
             app.mode = app::Mode::Help;
-            let _ = request_redraw.try_send(());
         }
+        (.., KeyCode::Char('c')) => {
+            let mut chart_type = CHART_TYPE.write().unwrap();
+            *chart_type = chart_type.toggle();
+        }
+        (.., KeyCode::Char('v')) => {
+            let mut show_volumes = SHOW_VOLUMES.write().unwrap();
+            *show_volumes = !*show_volumes;
+        }
+        (.., KeyCode::Char('p')) => {
+            let mut guard = ENABLE_PRE_POST.write().unwrap();
+            *guard = !*guard;
+        }
+        (Mode::DisplaySummary, modifiers, keycode) if modifiers.is_empty() => {
+            handle_keys_display_summary_(keycode, app)
+        }
+        (.., KeyCode::Char('x')) => {
+            let mut show_x_labels = SHOW_X_LABELS.write().unwrap();
+            *show_x_labels = !*show_x_labels;
+        }
+        (Mode::DisplayOptions, modifiers, keycode) if modifiers.is_empty() => {
+            handle_keys_display_options_(keycode, app)
+        }
+        (Mode::DisplayStock, modifiers, keycode) => {
+            handle_keys_display_stock_(keycode, modifiers, app)
+        }
+        _ => {}
     }
+    let _ = request_redraw.try_send(());
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -142,7 +142,7 @@ fn handle_keys_display_summary_(keycode: KeyCode, mut app: &mut app::App) {
 
 fn handle_keys_display_options_(keycode: KeyCode, mut app: &mut app::App) {
     match keycode {
-        KeyCode::Esc | KeyCode::Char('o') => {
+        KeyCode::Esc | KeyCode::Char('o') | KeyCode::Char('q') => {
             app.stocks[app.current_tab].toggle_options();
             app.mode = app::Mode::DisplayStock;
         }
@@ -250,7 +250,7 @@ pub fn handle_key_bindings(
         {
             app.mode = app.previous_mode;
         }
-        (.., KeyCode::Char('q')) => {
+        (mode, _, KeyCode::Char('q')) if mode != Mode::DisplayOptions => {
             cleanup_terminal();
             std::process::exit(0);
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -243,10 +243,10 @@ pub fn handle_key_bindings(
         }
         (Mode::Help, modifiers, keycode)
             if modifiers.is_empty()
-                && (match keycode {
-                    KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q') => true,
-                    _ => false,
-                }) =>
+                && (matches!(
+                    keycode,
+                    KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q')
+                )) =>
         {
             app.mode = app.previous_mode;
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,7 +6,7 @@ use crate::app::{self, Mode};
 use crate::widget::options;
 use crate::{cleanup_terminal, CHART_TYPE, ENABLE_PRE_POST, SHOW_VOLUMES, SHOW_X_LABELS};
 
-fn handle_keys_add_stock_(keycode: KeyCode, mut app: &mut app::App) {
+fn handle_keys_add_stock(keycode: KeyCode, mut app: &mut app::App) {
     match keycode {
         KeyCode::Enter => {
             let mut stock = app.add_stock.enter();
@@ -37,7 +37,7 @@ fn handle_keys_add_stock_(keycode: KeyCode, mut app: &mut app::App) {
     }
 }
 
-fn handle_keys_display_stock_(keycode: KeyCode, modifiers: KeyModifiers, mut app: &mut app::App) {
+fn handle_keys_display_stock(keycode: KeyCode, modifiers: KeyModifiers, mut app: &mut app::App) {
     match (keycode, modifiers) {
         (KeyCode::Left, KeyModifiers::CONTROL) => {
             let new_idx = if app.current_tab == 0 {
@@ -107,7 +107,7 @@ fn handle_keys_display_stock_(keycode: KeyCode, modifiers: KeyModifiers, mut app
     }
 }
 
-fn handle_keys_display_summary_(keycode: KeyCode, mut app: &mut app::App) {
+fn handle_keys_display_summary(keycode: KeyCode, mut app: &mut app::App) {
     match keycode {
         KeyCode::Left => {
             app.summary_time_frame = app.summary_time_frame.down();
@@ -140,7 +140,7 @@ fn handle_keys_display_summary_(keycode: KeyCode, mut app: &mut app::App) {
     }
 }
 
-fn handle_keys_display_options_(keycode: KeyCode, mut app: &mut app::App) {
+fn handle_keys_display_options(keycode: KeyCode, mut app: &mut app::App) {
     match keycode {
         KeyCode::Esc | KeyCode::Char('o') | KeyCode::Char('q') => {
             app.stocks[app.current_tab].toggle_options();
@@ -239,7 +239,7 @@ pub fn handle_key_bindings(
         (Mode::AddStock, modifiers, keycode)
             if modifiers.is_empty() || modifiers == KeyModifiers::SHIFT =>
         {
-            handle_keys_add_stock_(keycode, app)
+            handle_keys_add_stock(keycode, app)
         }
         (Mode::Help, modifiers, keycode)
             if modifiers.is_empty()
@@ -271,17 +271,17 @@ pub fn handle_key_bindings(
             *guard = !*guard;
         }
         (Mode::DisplaySummary, modifiers, keycode) if modifiers.is_empty() => {
-            handle_keys_display_summary_(keycode, app)
+            handle_keys_display_summary(keycode, app)
         }
         (.., KeyCode::Char('x')) => {
             let mut show_x_labels = SHOW_X_LABELS.write().unwrap();
             *show_x_labels = !*show_x_labels;
         }
         (Mode::DisplayOptions, modifiers, keycode) if modifiers.is_empty() => {
-            handle_keys_display_options_(keycode, app)
+            handle_keys_display_options(keycode, app)
         }
         (Mode::DisplayStock, modifiers, keycode) => {
-            handle_keys_display_stock_(keycode, modifiers, app)
+            handle_keys_display_stock(keycode, modifiers, app)
         }
         _ => {}
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -53,49 +53,6 @@ fn handle_keys_display_stock(keycode: KeyCode, modifiers: KeyModifiers, mut app:
             app.stocks.swap(app.current_tab, new_idx);
             app.current_tab = new_idx;
         }
-        (KeyCode::Left, _) => {
-            app.stocks[app.current_tab].time_frame_down();
-        }
-        (KeyCode::Right, _) => {
-            app.stocks[app.current_tab].time_frame_up();
-        }
-        (KeyCode::Char('/'), _) => {
-            app.previous_mode = app.mode;
-            app.mode = app::Mode::AddStock;
-        }
-        (KeyCode::Char('k'), _) => {
-            app.stocks.remove(app.current_tab);
-
-            if app.current_tab != 0 {
-                app.current_tab -= 1;
-            }
-
-            if app.stocks.is_empty() {
-                app.previous_mode = app.mode;
-                app.mode = app::Mode::AddStock;
-            }
-        }
-        (KeyCode::Char('s'), _) => {
-            app.mode = app::Mode::DisplaySummary;
-
-            for stock in app.stocks.iter_mut() {
-                if stock.time_frame != app.summary_time_frame {
-                    stock.set_time_frame(app.summary_time_frame);
-                }
-            }
-        }
-        (KeyCode::Char('o'), _) => {
-            if app.stocks[app.current_tab].toggle_options() {
-                app.mode = app::Mode::DisplayOptions;
-            }
-        }
-        (KeyCode::Tab, _) => {
-            if app.current_tab == app.stocks.len() - 1 {
-                app.current_tab = 0;
-            } else {
-                app.current_tab += 1;
-            }
-        }
         (KeyCode::BackTab, KeyModifiers::SHIFT) => {
             if app.current_tab == 0 {
                 app.current_tab = app.stocks.len() - 1;
@@ -103,6 +60,52 @@ fn handle_keys_display_stock(keycode: KeyCode, modifiers: KeyModifiers, mut app:
                 app.current_tab -= 1;
             }
         }
+        (keycode, modifiers) if modifiers.is_empty() => match keycode {
+            KeyCode::Left => {
+                app.stocks[app.current_tab].time_frame_down();
+            }
+            KeyCode::Right => {
+                app.stocks[app.current_tab].time_frame_up();
+            }
+            KeyCode::Char('/') => {
+                app.previous_mode = app.mode;
+                app.mode = app::Mode::AddStock;
+            }
+            KeyCode::Char('k') => {
+                app.stocks.remove(app.current_tab);
+
+                if app.current_tab != 0 {
+                    app.current_tab -= 1;
+                }
+
+                if app.stocks.is_empty() {
+                    app.previous_mode = app.mode;
+                    app.mode = app::Mode::AddStock;
+                }
+            }
+            KeyCode::Char('s') => {
+                app.mode = app::Mode::DisplaySummary;
+
+                for stock in app.stocks.iter_mut() {
+                    if stock.time_frame != app.summary_time_frame {
+                        stock.set_time_frame(app.summary_time_frame);
+                    }
+                }
+            }
+            KeyCode::Char('o') => {
+                if app.stocks[app.current_tab].toggle_options() {
+                    app.mode = app::Mode::DisplayOptions;
+                }
+            }
+            KeyCode::Tab => {
+                if app.current_tab == app.stocks.len() - 1 {
+                    app.current_tab = 0;
+                } else {
+                    app.current_tab += 1;
+                }
+            }
+            _ => {}
+        },
         _ => {}
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,23 +163,7 @@ fn main() {
 
                 match message {
                     Ok(Event::Key(key_event)) => {
-                        match app.mode {
-                            app::Mode::AddStock => {
-                                event::handle_keys_add_stock(key_event, &mut app, &request_redraw);
-                            }
-                            app::Mode::DisplayStock => {
-                                event::handle_keys_display_stock(key_event,&mut app, &request_redraw);
-                            }
-                            app::Mode::DisplaySummary => {
-                                event::handle_keys_display_summary(key_event, &mut app, &request_redraw);
-                            }
-                            app::Mode::Help => {
-                                event::handle_keys_help(key_event, &mut app, &request_redraw);
-                            }
-                            app::Mode::DisplayOptions => {
-                                event::handle_keys_display_options(key_event, &mut app, &request_redraw);
-                            }
-                        }
+                        event::handle_key_bindings(app.mode, key_event, &mut app, &request_redraw);
                     }
                     Ok(Event::Mouse(MouseEvent { kind, row, column,.. })) => {
                         if app.debug.enabled {


### PR DESCRIPTION
In reference to conversation https://github.com/tarkah/tickrs/pull/93#issuecomment-785456170, https://github.com/tarkah/tickrs/pull/93#issuecomment-785460109 and https://github.com/tarkah/tickrs/pull/93#issuecomment-785465182.

This PR:
  - unifies <kbd>ctrl</kbd>+<kbd>c</kbd> on all panes
  - unifies <kbd>?</kbd> across panes with exceptional behavior on the help pane
  - unifies <kbd>q</kbd> across panes with exceptional behavior on the help, addstock, and options pane
  - allows useful toggles like <kbd>c</kbd>, <kbd>v</kbd>, <kbd>p</kbd> on all panes except help and addstock (especially including the options pane)
  - allows <kbd>x</kbd> on all panes except help, addstock and summary (especially including the options pane)

### keymap (top-down in match order)

| bindings | where | action |
| - | - | - |
| <kbd>ctrl</kbd>+<kbd>c</kbd> | `Mode::*` | exit app |
| <kbd>enter</kbd> | `Mode::AddStock` | add stock |
| <kbd>[char]</kbd> | `Mode::AddStock` | type character in stock bar |
| <kbd>backspace</kbd> | `Mode::AddStock` | delete character in stock bar |
| <kbd>esc</kbd> | `Mode::AddStock` | close stock bar |
| <kbd>esc</kbd> \| <kbd>q</kbd> \| <kbd>?</kbd> | `Mode::Help` | close help window |
| <kbd>q</kbd> | `Mode::*` *(if not `Mode::DisplayOptions`)* | exit app |
| <kbd>?</kbd> | `Mode::*` | open help window |
| <kbd>c</kbd> | `Mode::*` | toggle chart type |
| <kbd>v</kbd> | `Mode::*` | toggle volumes on/off |
| <kbd>p</kbd> | `Mode::*` | toggle pre-post |
| <kbd>Left</kbd> | `Mode::DisplaySummary` | select timeframe to the left |
| <kbd>Right</kbd> | `Mode::DisplaySummary` | select timeframe to the right |
| <kbd>Up</kbd> | `Mode::DisplaySummary` | scroll up |
| <kbd>Down</kbd> | `Mode::DisplaySummary` | scroll down |
| <kbd>s</kbd> | `Mode::DisplaySummary` | switch to stock view |
| <kbd>/</kbd> | `Mode::DisplaySummary` | add new stock |
| <kbd>x</kbd> | `Mode::*` | toggle x-axis labels |
| <kbd>esc</kbd> \| <kbd>o</kbd> \| <kbd>q</kbd> | `Mode::DisplayOptions` | close options pane |
| <kbd>tab</kbd> | `Mode::DisplayOptions` | toggle call/puts |
| <kbd>Up</kbd> | `Mode::DisplayOptions` | navigate up |
| <kbd>Down</kbd> | `Mode::DisplayOptions` | navigate down |
| <kbd>Left</kbd> | `Mode::DisplayOptions` | navigate left |
| <kbd>Right</kbd> | `Mode::DisplayOptions` | navigate right |
| <kbd>ctrl</kbd>+<kbd>Left</kbd> | `Mode::DisplayStock` | move stock left |
| <kbd>ctrl</kbd>+<kbd>Right</kbd> | `Mode::DisplayStock` | move stock right |
| <kbd>Left</kbd> | `Mode::DisplayStock` | select timeframe to the left |
| <kbd>Right</kbd> | `Mode::DisplayStock` | select timeframe to the left |
| <kbd>/</kbd> | `Mode::DisplayStock` | add new stock |
| <kbd>k</kbd> | `Mode::DisplayStock` | remove selected stock |
| <kbd>s</kbd> | `Mode::DisplayStock` | switch to summary view |
| <kbd>o</kbd> | `Mode::DisplayStock` | open options pane |
| <kbd>tab</kbd> | `Mode::DisplayStock` | select tab to the left |
| <kbd>shift</kbd>+<kbd>tab</kbd> | `Mode::DisplayStock` | select tab to the right |