### PR TITLE
disable q:quit with kagi config pane open

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -308,7 +308,9 @@ pub fn handle_key_bindings(
                 app.mode = app.previous_mode;
             }
         }
-        (mode, KeyModifiers::NONE, KeyCode::Char('q')) if mode != Mode::DisplayOptions => {
+        (mode, KeyModifiers::NONE, KeyCode::Char('q'))
+            if !matches!(mode, Mode::DisplayOptions | Mode::ConfigureChart) =>
+        {
             cleanup_terminal();
             std::process::exit(0);
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -247,7 +247,7 @@ fn handle_keys_display_options(keycode: KeyCode, mut app: &mut app::App) {
 
 pub fn handle_keys_configure_chart(keycode: KeyCode, mut app: &mut app::App) {
     match keycode {
-        KeyCode::Esc | KeyCode::Char('e') => {
+        KeyCode::Esc | KeyCode::Char('e') | KeyCode::Char('q') => {
             app.stocks[app.current_tab].toggle_configure();
             app.mode = app::Mode::DisplayStock;
         }


### PR DESCRIPTION
Do not quit when <kbd>q</kbd> is pressed while in the kagi configurations pane.

In ref to #93