### PR TITLE
intuitive keybindings

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -251,21 +251,21 @@ pub fn handle_keys_configure_chart(keycode: KeyCode, mut app: &mut app::App) {
             app.stocks[app.current_tab].toggle_configure();
             app.mode = app::Mode::DisplayStock;
         }
-        KeyCode::Up => {
+        KeyCode::Up | KeyCode::BackTab => {
             let config = app.stocks[app.current_tab].chart_config_mut();
             config.selection_up();
         }
-        KeyCode::Down => {
+        KeyCode::Down | KeyCode::Tab => {
             let config = app.stocks[app.current_tab].chart_config_mut();
             config.selection_down();
         }
-        KeyCode::Tab => {
-            let config = app.stocks[app.current_tab].chart_config_mut();
-            config.tab();
-        }
-        KeyCode::BackTab => {
+        KeyCode::Left => {
             let config = app.stocks[app.current_tab].chart_config_mut();
             config.back_tab();
+        }
+        KeyCode::Right => {
+            let config = app.stocks[app.current_tab].chart_config_mut();
+            config.tab();
         }
         KeyCode::Enter => {
             let time_frame = app.stocks[app.current_tab].time_frame;

--- a/src/widget/chart_configuration.rs
+++ b/src/widget/chart_configuration.rs
@@ -285,7 +285,7 @@ impl CachableWidget<ChartConfigurationState> for ChartConfigurationWidget {
         // layout[0] - Info / Error message
         // layout[1] - Kagi options
         let mut layout = Layout::default()
-            .constraints([Constraint::Length(5), Constraint::Min(0)])
+            .constraints([Constraint::Length(6), Constraint::Min(0)])
             .split(area);
 
         layout[0] = add_padding(layout[0], 1, PaddingDirection::Top);

--- a/src/widget/chart_configuration.rs
+++ b/src/widget/chart_configuration.rs
@@ -300,7 +300,11 @@ impl CachableWidget<ChartConfigurationState> for ChartConfigurationWidget {
                     style().fg(THEME.text_normal()),
                 )),
                 Spans::from(Span::styled(
-                    "  <Tab>: toggle option",
+                    "  <Tab / Shift+Tab>: move up / down",
+                    style().fg(THEME.text_normal()),
+                )),
+                Spans::from(Span::styled(
+                    "  <Left / Right>: toggle option",
                     style().fg(THEME.text_normal()),
                 )),
                 Spans::from(Span::styled(


### PR DESCRIPTION
This PR attempts to closely match widget interactions.

<kbd>tab</kbd> / <kbd>shift</kbd>+<kbd>tab</kbd> is preferrably a keybinding for jumping between distinct widgets.

So, intuitively we defer to the use of <kbd>Left</kbd> / <kbd>Right</kbd> to select between options.

This merges #103, and is in ref to #93