### PR TITLE
allow chart scroll with side pane open

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -67,20 +67,6 @@ fn handle_keys_display_stock(keycode: KeyCode, modifiers: KeyModifiers, mut app:
         (KeyCode::Right, KeyModifiers::NONE) => {
             app.stocks[app.current_tab].time_frame_up();
         }
-        (KeyCode::Left, KeyModifiers::SHIFT) | (KeyCode::Char('<'), KeyModifiers::NONE) => {
-            if let Some(stock) = app.stocks.get_mut(app.current_tab) {
-                if let Some(chart_state) = stock.chart_state_mut() {
-                    chart_state.scroll_left();
-                }
-            }
-        }
-        (KeyCode::Right, KeyModifiers::SHIFT) | (KeyCode::Char('>'), KeyModifiers::NONE) => {
-            if let Some(stock) = app.stocks.get_mut(app.current_tab) {
-                if let Some(chart_state) = stock.chart_state_mut() {
-                    chart_state.scroll_right();
-                }
-            }
-        }
         (KeyCode::Char('/'), KeyModifiers::NONE) => {
             app.previous_mode = app.mode;
             app.mode = app::Mode::AddStock;
@@ -351,6 +337,20 @@ pub fn handle_key_bindings(
         (Mode::DisplayOptions, modifiers, keycode) => {
             if modifiers.is_empty() {
                 handle_keys_display_options(keycode, app)
+            }
+        }
+        (_, KeyModifiers::SHIFT, KeyCode::Left) | (_, KeyModifiers::NONE, KeyCode::Char('<')) => {
+            if let Some(stock) = app.stocks.get_mut(app.current_tab) {
+                if let Some(chart_state) = stock.chart_state_mut() {
+                    chart_state.scroll_left();
+                }
+            }
+        }
+        (_, KeyModifiers::SHIFT, KeyCode::Right) | (_, KeyModifiers::NONE, KeyCode::Char('>')) => {
+            if let Some(stock) = app.stocks.get_mut(app.current_tab) {
+                if let Some(chart_state) = stock.chart_state_mut() {
+                    chart_state.scroll_right();
+                }
             }
         }
         (Mode::ConfigureChart, modifiers, keycode) => {

--- a/src/event.rs
+++ b/src/event.rs
@@ -334,11 +334,6 @@ pub fn handle_key_bindings(
             let mut show_x_labels = SHOW_X_LABELS.write().unwrap();
             *show_x_labels = !*show_x_labels;
         }
-        (Mode::DisplayOptions, modifiers, keycode) => {
-            if modifiers.is_empty() {
-                handle_keys_display_options(keycode, app)
-            }
-        }
         (_, KeyModifiers::SHIFT, KeyCode::Left) | (_, KeyModifiers::NONE, KeyCode::Char('<')) => {
             if let Some(stock) = app.stocks.get_mut(app.current_tab) {
                 if let Some(chart_state) = stock.chart_state_mut() {
@@ -351,6 +346,11 @@ pub fn handle_key_bindings(
                 if let Some(chart_state) = stock.chart_state_mut() {
                     chart_state.scroll_right();
                 }
+            }
+        }
+        (Mode::DisplayOptions, modifiers, keycode) => {
+            if modifiers.is_empty() {
+                handle_keys_display_options(keycode, app)
             }
         }
         (Mode::ConfigureChart, modifiers, keycode) => {


### PR DESCRIPTION
Allow chart scrolling when a side pane (options or config) is open

This merges #105, and is in ref to #93