### PR TITLE
fix clippy::manual-map

### DIFF
--- a/src/widget/chart/prices_line.rs
+++ b/src/widget/chart/prices_line.rs
@@ -93,18 +93,14 @@ impl<'a> StatefulWidget for PricesLineChart<'a> {
                         }
                     },
                     {
-                        if let Some(post_start_idx) = end_idx {
-                            Some(
-                                prices
-                                    .iter()
-                                    .enumerate()
-                                    .filter(|(idx, _)| *idx >= post_start_idx)
-                                    .map(cast_as_dataset)
-                                    .collect::<Vec<(f64, f64)>>(),
-                            )
-                        } else {
-                            None
-                        }
+                        end_idx.map(|post_start_idx| {
+                            prices
+                                .iter()
+                                .enumerate()
+                                .filter(|(idx, _)| *idx >= post_start_idx)
+                                .map(cast_as_dataset)
+                                .collect::<Vec<(f64, f64)>>()
+                        })
                     },
                 )
             } else {


### PR DESCRIPTION
Fix [`clippy::manual-map`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_map)

```rust
error: manual implementation of `Option::map`
Error:    --> src/widget/chart/prices_line.rs:96:25
    |
96  | /                         if let Some(post_start_idx) = end_idx {
97  | |                             Some(
98  | |                                 prices
99  | |                                     .iter()
...   |
106 | |                             None
107 | |                         }
    | |_________________________^
    |
    = note: `-D clippy::manual-map` implied by `-D warnings`
```