### PR TITLE
update README.md about installation for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Download the latest [release](https://github.com/tarkah/tickrs/releases/latest) 
 cargo install tickrs
 ```
 
-### AUR
+### Arch Linux
 
 ```
-yay -S tickrs-git
+pacman -S tickrs
 ```
 
 ### Homebrew


### PR DESCRIPTION
`tickrs` is now in community repository: https://archlinux.org/packages/community/x86_64/tickrs/