### PR TITLE
Fix non-US stock charts

### DIFF
--- a/src/widget/block.rs
+++ b/src/widget/block.rs
@@ -4,7 +4,7 @@ use ratatui::widgets::{Block, Borders};
 use crate::theme::style;
 use crate::THEME;
 
-pub fn new(title: &str) -> Block {
+pub fn new(title: &'_ str) -> Block<'_> {
     Block::default()
         .borders(Borders::ALL)
         .border_style(style().fg(THEME.border_primary()))

--- a/src/widget/chart/prices_kagi.rs
+++ b/src/widget/chart/prices_kagi.rs
@@ -590,7 +590,7 @@ impl StatefulWidget for PricesKagiChart<'_> {
     }
 }
 
-fn x_labels(width: u16, trends: &[Trend], time_frame: TimeFrame) -> Vec<Span> {
+fn x_labels(width: u16, trends: &'_ [Trend], time_frame: TimeFrame) -> Vec<Span<'_>> {
     let mut labels = vec![];
 
     let trends = trends

--- a/src/widget/stock.rs
+++ b/src/widget/stock.rs
@@ -135,17 +135,10 @@ impl StockState {
 
     pub fn prices(&self) -> impl Iterator<Item = Price> {
         let (start, end) = self.start_end();
+        let mut prices = self.prices[self.time_frame.idx()].clone();
 
-        let prices = self.prices[self.time_frame.idx()].clone();
-
-        let max_time = prices.last().map(|p| p.date).unwrap_or(end);
-
-        let default_timestamps = {
-            let defaults = DEFAULT_TIMESTAMPS.read();
-            defaults.get(&self.time_frame).cloned()
-        };
-
-        let prices = if self.time_frame == TimeFrame::Day1 {
+        if self.time_frame == TimeFrame::Day1 {
+            let max_time = prices.last().map(|p| p.date).unwrap_or(end);
             let times = MarketHours(
                 start,
                 if max_time < start {
@@ -155,7 +148,7 @@ impl StockState {
                 },
             );
 
-            times
+            prices = times
                 .map(|t| {
                     if let Some(p) = prices.iter().find(|p| {
                         let min_rounded = p.date - p.date % 60;
@@ -170,31 +163,8 @@ impl StockState {
                         }
                     }
                 })
-                .collect::<Vec<_>>()
-        } else if self.is_crypto() {
-            prices
-        } else if let Some(default_timestamps) = default_timestamps {
-            default_timestamps
-                .into_iter()
-                .map(|t| {
-                    if let Some(p) = prices.iter().find(|p| {
-                        let a_rounded = p.date - p.date % self.time_frame.round_by();
-                        let b_rounded = t - t % self.time_frame.round_by();
-
-                        a_rounded == b_rounded
-                    }) {
-                        *p
-                    } else {
-                        Price {
-                            date: t,
-                            ..Default::default()
-                        }
-                    }
-                })
-                .collect::<Vec<_>>()
-        } else {
-            prices
-        };
+                .collect::<Vec<_>>();
+        }
 
         prices.into_iter()
     }

--- a/src/widget/stock.rs
+++ b/src/widget/stock.rs
@@ -413,7 +413,7 @@ impl StockState {
         }
     }
 
-    pub fn x_labels(&self, width: u16, start: i64, end: i64, data: &[Price]) -> Vec<Span> {
+    pub fn x_labels(&'_ self, width: u16, start: i64, end: i64, data: &[Price]) -> Vec<Span<'_>> {
         let mut labels = vec![];
 
         let dates = if self.time_frame == TimeFrame::Day1 {
@@ -457,7 +457,7 @@ impl StockState {
         [(min), (max)]
     }
 
-    pub fn y_labels(&self, min: f64, max: f64) -> Vec<Span> {
+    pub fn y_labels(&'_ self, min: f64, max: f64) -> Vec<Span<'_>> {
         if self.loaded() {
             vec![
                 Span::styled(


### PR DESCRIPTION
Closes https://github.com/tarkah/tickrs/issues/184

As discussed in the issue above, many if not all non-US stocks are broken when viewing the chart with a time frame other than one day.

Currently all Price objects that don't happen to align with a date fetched from SPY are discarded. This works for US stocks, but breaks non-US stocks such that only a fraction of the graph is correct and the rest is just a flat line connecting the adjacent valid points.

At first I tried making the chart match the current behaviour as closely as possible rather than just naively stretching the chart to the screen edges even though the available data spans a shorter period of time. 

The problem with that approach was that it not only requires additional code to retrieve the current time and the time of the beginning, but it also adds some unnecessary padding to both sides of the chart unless it is clamped to the edges of the screen if the error is small enough. Additionally, you would need to probably fetch the time of the market opening/closing so that the threshold is not exceeded.

Honestly I think it is fine if the chart is stretched and that some timelines might not match 1:1 with each other in the summary view.

You can see the difference from the picture below. The picture on the right-hand side shows what it looked like before applying this change:

<img width="1918" height="981" alt="image" src="https://github.com/user-attachments/assets/ce97195c-0e7e-400a-a208-a3745b9e4d0f" />


Here's the stretching I mentioned. Notice how the picture on the left-hand side doesn't contain any padding on the left even though the stock doesn't have five years of price data required to actually fill the whole timeline:

<img width="1918" height="981" alt="image" src="https://github.com/user-attachments/assets/3148f1f3-9052-4c03-8525-20ebd48fdfbe" />