### PR TITLE
Switch from per stock time frame to global time frame

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -24,7 +24,7 @@ pub struct App {
     pub hide_help: bool,
     pub debug: DebugInfo,
     pub previous_mode: Mode,
-    pub summary_time_frame: TimeFrame,
+    pub time_frame: TimeFrame,
     pub default_timestamp_service: DefaultTimestampService,
     pub summary_scroll_state: SummaryScrollState,
     pub chart_type: ChartType,
@@ -36,6 +36,22 @@ impl App {
 
         if let Some(new_defaults) = timestamp_updates.pop() {
             *DEFAULT_TIMESTAMPS.write() = new_defaults;
+        }
+    }
+
+    pub fn time_frame_up(&mut self) {
+        self.set_time_frame(self.time_frame.up());
+    }
+
+    pub fn time_frame_down(&mut self) {
+        self.set_time_frame(self.time_frame.down());
+    }
+
+    pub fn set_time_frame(&mut self, time_frame: TimeFrame) {
+        self.time_frame = time_frame;
+
+        for stock in self.stocks.iter_mut() {
+            stock.set_time_frame(time_frame);
         }
     }
 }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -379,7 +379,7 @@ fn draw_summary(frame: &mut Frame, app: &mut App, mut area: Rect) {
             .to_vec();
 
         let tabs = Tabs::new(time_frames)
-            .select(app.summary_time_frame.idx())
+            .select(app.time_frame.idx())
             .style(style().fg(THEME.text_secondary()))
             .highlight_style(style().fg(THEME.text_primary()));
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -12,9 +12,7 @@ fn handle_keys_add_stock(keycode: KeyCode, app: &mut app::App) {
         KeyCode::Enter => {
             let mut stock = app.add_stock.enter(app.chart_type);
 
-            if app.previous_mode == app::Mode::DisplaySummary {
-                stock.set_time_frame(app.summary_time_frame);
-            }
+            stock.set_time_frame(app.time_frame);
 
             app.stocks.push(stock);
             app.current_tab = app.stocks.len() - 1;
@@ -62,10 +60,10 @@ fn handle_keys_display_stock(keycode: KeyCode, modifiers: KeyModifiers, app: &mu
             }
         }
         (KeyCode::Left, KeyModifiers::NONE) => {
-            app.stocks[app.current_tab].time_frame_down();
+            app.time_frame_down();
         }
         (KeyCode::Right, KeyModifiers::NONE) => {
-            app.stocks[app.current_tab].time_frame_up();
+            app.time_frame_up();
         }
         (KeyCode::Char('/'), KeyModifiers::NONE) => {
             app.previous_mode = app.mode;
@@ -85,12 +83,6 @@ fn handle_keys_display_stock(keycode: KeyCode, modifiers: KeyModifiers, app: &mu
         }
         (KeyCode::Char('s'), KeyModifiers::NONE) => {
             app.mode = app::Mode::DisplaySummary;
-
-            for stock in app.stocks.iter_mut() {
-                if stock.time_frame != app.summary_time_frame {
-                    stock.set_time_frame(app.summary_time_frame);
-                }
-            }
         }
         (KeyCode::Char('o'), KeyModifiers::NONE) => {
             if app.stocks[app.current_tab].toggle_options() {
@@ -116,18 +108,10 @@ fn handle_keys_display_stock(keycode: KeyCode, modifiers: KeyModifiers, app: &mu
 fn handle_keys_display_summary(keycode: KeyCode, app: &mut app::App) {
     match keycode {
         KeyCode::Left => {
-            app.summary_time_frame = app.summary_time_frame.down();
-
-            for stock in app.stocks.iter_mut() {
-                stock.set_time_frame(app.summary_time_frame);
-            }
+            app.time_frame_down();
         }
         KeyCode::Right => {
-            app.summary_time_frame = app.summary_time_frame.up();
-
-            for stock in app.stocks.iter_mut() {
-                stock.set_time_frame(app.summary_time_frame);
-            }
+            app.time_frame_up();
         }
         KeyCode::Up => {
             app.summary_scroll_state.queued_scroll = Some(ScrollDirection::Up);

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn main() {
         } else {
             app::Mode::DisplayStock
         },
-        summary_time_frame: opts.time_frame.unwrap_or(TimeFrame::Day1),
+        time_frame: opts.time_frame.unwrap_or(TimeFrame::Day1),
         default_timestamp_service,
         summary_scroll_state: Default::default(),
         chart_type: starting_chart_type,

--- a/src/widget/stock.rs
+++ b/src/widget/stock.rs
@@ -116,14 +116,6 @@ impl StockState {
         &self.symbol
     }
 
-    pub fn time_frame_up(&mut self) {
-        self.set_time_frame(self.time_frame.up());
-    }
-
-    pub fn time_frame_down(&mut self) {
-        self.set_time_frame(self.time_frame.down());
-    }
-
     pub fn set_time_frame(&mut self, time_frame: TimeFrame) {
         self.time_frame = time_frame;
 


### PR DESCRIPTION
I personally find the per stock time frame setting confusing. Changing from one time frame to another should change it for each stock, regardless of whether the current view is summary or not. To make matters even worse, the individual time frame settings are reset each time one changes the current view from normal to summary or vice versa.

This PR simply makes it so that the time frame is changed for each stock whenever it is changed for one.