### PR TITLE
Dynamic stock chart height in the summary view

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -5,14 +5,14 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph, Tabs, Wrap};
 use ratatui::{Frame, Terminal};
 
 use crate::app::{App, Mode, ScrollDirection};
-use crate::common::{ChartType, TimeFrame};
+use crate::common::TimeFrame;
 use crate::service::Service;
 use crate::theme::style;
 use crate::widget::{
     block, AddStockWidget, ChartConfigurationWidget, OptionsWidget, StockSummaryWidget,
     StockWidget, HELP_HEIGHT, HELP_WIDTH,
 };
-use crate::{SHOW_VOLUMES, THEME};
+use crate::THEME;
 
 pub fn draw(terminal: &mut Terminal<impl Backend>, app: &mut App) {
     let current_size = terminal.size().unwrap_or_default();
@@ -246,11 +246,12 @@ fn draw_summary(frame: &mut Frame, app: &mut App, mut area: Rect) {
     area = add_padding(area, 1, PaddingDirection::All);
     area = add_padding(area, 1, PaddingDirection::Right);
 
-    let show_volumes = *SHOW_VOLUMES.read() && app.chart_type != ChartType::Kagi;
-    let stock_widget_height = if show_volumes { 7 } else { 6 };
+    // Space available for the stocks after taking borders and such into account
+    let height = area.height - 3 + app.hide_help as u16;
 
-    let height = area.height;
-    let num_to_render = (((height - 3) / stock_widget_height) as usize).min(app.stocks.len());
+    // The minimum height a stock chart will use
+    let stock_widget_height = (height / app.stocks.len() as u16).max(6);
+    let num_to_render = ((height / stock_widget_height) as usize).min(app.stocks.len());
 
     // If the user queued an up / down scroll, calculate the new offset, store it in
     // state and use it for this render. Otherwise use stored offset from state.
@@ -281,13 +282,13 @@ fn draw_summary(frame: &mut Frame, app: &mut App, mut area: Rect) {
         app.summary_scroll_state.offset = scroll_offset;
     }
 
-    // layouy[0] - Header
-    // layouy[1] - Summary window
+    // layouy[0] - Header. 1 if shown, 0 if not
+    // layouy[1] - Summary window, use all available space
     // layouy[2] - Empty
     let mut layout = Layout::default()
         .constraints([
-            Constraint::Length(1),
-            Constraint::Length((num_to_render * stock_widget_height as usize) as u16),
+            Constraint::Length(!app.hide_help as u16),
+            Constraint::Length(height),
             Constraint::Min(0),
         ])
         .split(area)

--- a/src/widget/chart/prices_kagi.rs
+++ b/src/widget/chart/prices_kagi.rs
@@ -410,7 +410,7 @@ impl StatefulWidget for PricesKagiChart<'_> {
             // Plot labels on
             let mut x_area = x_layout[1];
             x_area.x = layout[1].x + 1;
-            x_area.width = (num_trends_can_render.min(num_trends) * 1.5).floor() as u16;
+            x_area.width = layout[1].width - 1;
 
             // Fix for y label render
             layout[0] = add_padding(layout[0], 1, PaddingDirection::Bottom);

--- a/src/widget/chart/prices_line.rs
+++ b/src/widget/chart/prices_line.rs
@@ -1,11 +1,13 @@
 use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::symbols::Marker;
+use ratatui::text::Span;
 use ratatui::widgets::{Axis, Block, Borders, Chart, Dataset, GraphType, StatefulWidget, Widget};
 
 use crate::common::{
     cast_as_dataset, cast_historical_as_price, zeros_as_pre, Price, TimeFrame, TradingPeriod,
 };
+use crate::draw::{add_padding, PaddingDirection};
 use crate::theme::style;
 use crate::widget::StockState;
 use crate::{HIDE_PREV_CLOSE, THEME};
@@ -22,7 +24,19 @@ pub struct PricesLineChart<'a> {
 impl StatefulWidget for PricesLineChart<'_> {
     type State = StockState;
 
-    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+    fn render(self, mut area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        if area.width <= 9 || area.height <= 3 {
+            return;
+        }
+
+        if !self.is_summary {
+            Block::default()
+                .borders(Borders::TOP)
+                .border_style(style().fg(THEME.border_secondary()))
+                .render(area, buf);
+            area = add_padding(area, 1, PaddingDirection::Top);
+        }
+
         let (min, max) = state.min_max(self.data);
         let (start, end) = state.start_end();
 
@@ -37,12 +51,6 @@ impl StatefulWidget for PricesLineChart<'_> {
             GraphType::Scatter
         } else {
             GraphType::Line
-        };
-
-        let x_labels = if self.show_x_labels {
-            state.x_labels(area.width, start, end, self.data)
-        } else {
-            vec![]
         };
 
         let trading_period = state.current_trading_period(self.data);
@@ -191,33 +199,101 @@ impl StatefulWidget for PricesLineChart<'_> {
             );
         }
 
-        let mut chart = Chart::new(datasets)
-            .style(style())
-            .x_axis({
-                let axis = Axis::default().bounds(state.x_bounds(start, end, self.data));
-
-                if self.show_x_labels && self.loaded && !self.is_summary {
-                    axis.labels(x_labels).style(style().fg(THEME.border_axis()))
-                } else {
-                    axis
-                }
-            })
-            .y_axis(
-                Axis::default()
-                    .bounds(state.y_bounds(min, max))
-                    .labels(state.y_labels(min, max))
-                    .style(style().fg(THEME.border_axis())),
-            );
-
-        if !self.is_summary {
-            chart = chart.block(
+        let chart = Chart::new(datasets)
+            .block(
                 Block::default()
-                    .style(style().fg(THEME.border_secondary()))
-                    .borders(Borders::TOP)
-                    .border_style(style()),
-            );
+                    .style(style())
+                    .borders(if self.show_x_labels {
+                        Borders::LEFT | Borders::BOTTOM
+                    } else {
+                        Borders::LEFT
+                    })
+                    .border_style(style().fg(THEME.border_axis())),
+            )
+            .style(style())
+            .x_axis(Axis::default().bounds(state.x_bounds(start, end, self.data)))
+            .y_axis(Axis::default().bounds(state.y_bounds(min, max)));
+
+        // x_layout[0] - chart + y labels
+        // x_layout[1] - (x labels)
+        let x_layout: Vec<Rect> = Layout::default()
+            .constraints(if self.show_x_labels {
+                &[Constraint::Min(0), Constraint::Length(1)][..]
+            } else {
+                &[Constraint::Min(0)][..]
+            })
+            .split(area)
+            .to_vec();
+
+        // layout[0] - Y lables
+        // layout[1] - chart
+        let mut layout: Vec<Rect> = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Length(if !self.loaded {
+                    8
+                } else if self.show_x_labels {
+                    match state.time_frame {
+                        TimeFrame::Day1 => 9,
+                        TimeFrame::Week1 => 12,
+                        _ => 11,
+                    }
+                } else {
+                    9
+                }),
+                Constraint::Min(0),
+            ])
+            .split(x_layout[0])
+            .to_vec();
+
+        // Fix for border render
+        layout[1].x = layout[1].x.saturating_sub(1);
+        layout[1].width += 1;
+
+        // Draw x labels
+        if self.show_x_labels && self.loaded {
+            // Fix for y label render
+            layout[0] = add_padding(layout[0], 1, PaddingDirection::Bottom);
+
+            let mut x_area = x_layout[1];
+            x_area.x = layout[1].x + 1;
+            x_area.width = layout[1].width - 1;
+
+            let labels = state.x_labels(area.width, start, end, self.data);
+            let total_width = labels.iter().map(Span::width).sum::<usize>() as u16;
+            let labels_len = labels.len() as u16;
+            if total_width < x_area.width && labels_len > 1 {
+                for (i, label) in labels.iter().enumerate() {
+                    buf.set_span(
+                        x_area.left() + i as u16 * (x_area.width - 1) / (labels_len - 1)
+                            - label.width() as u16,
+                        x_area.top(),
+                        label,
+                        label.width() as u16,
+                    );
+                }
+            }
         }
 
-        chart.render(area, buf);
+        // Draw y labels
+        if self.loaded {
+            let y_area = layout[0];
+
+            let labels = state.y_labels(min, max);
+            let labels_len = labels.len() as u16;
+            for (i, label) in labels.iter().enumerate() {
+                let dy = i as u16 * (y_area.height - 1) / (labels_len - 1);
+                if dy < y_area.bottom() {
+                    buf.set_span(
+                        y_area.left(),
+                        y_area.bottom() - 1 - dy,
+                        label,
+                        label.width() as u16,
+                    );
+                }
+            }
+        }
+
+        chart.render(layout[1], buf);
     }
 }

--- a/src/widget/help.rs
+++ b/src/widget/help.rs
@@ -32,10 +32,10 @@ Toggle Summary Pane:
 const RIGHT_TEXT: &str = r#"
 Remove Stock: k
 Graphing Display:
-  - c: toggle candlestick chart
+  - c: switch chart type
   - p: toggle pre / post market
   - v: toggle volumes graph
-  - x: toggle labels
+  - x: toggle date labels
 Toggle Options Pane:
   - o: toggle pane
   - <Escape>: close pane

--- a/src/widget/stock.rs
+++ b/src/widget/stock.rs
@@ -822,7 +822,8 @@ impl CachableWidget<StockState> for StockWidget {
 
                 if loaded {
                     left_info.push(Line::from(Span::styled(
-                        format!("{: <8} 'c'", chart_type.as_str()),
+                        // We're calling toggle() since that returns the next chart type
+                        format!("{: <8} 'c'", chart_type.toggle().as_str()),
                         style(),
                     )));
 
@@ -842,7 +843,7 @@ impl CachableWidget<StockState> for StockWidget {
                     )));
 
                     left_info.push(Line::from(Span::styled(
-                        "X Labels 'x'",
+                        "Date     'x'",
                         style().bg(if show_x_labels {
                             THEME.highlight_unfocused()
                         } else {

--- a/src/widget/stock.rs
+++ b/src/widget/stock.rs
@@ -902,7 +902,7 @@ impl CachableWidget<StockState> for StockWidget {
         // graph_chunks[1] = volume
         let graph_chunks: Vec<Rect> = if show_volumes {
             Layout::default()
-                .constraints([Constraint::Min(6), Constraint::Length(5)].as_ref())
+                .constraints([Constraint::Min(0), Constraint::Percentage(25)].as_ref())
                 .split(chunks[1])
                 .to_vec()
         } else {

--- a/src/widget/stock_summary.rs
+++ b/src/widget/stock_summary.rs
@@ -160,7 +160,7 @@ impl CachableWidget<StockState> for StockSummaryWidget {
         // graph_chunks[1] = volume
         let graph_chunks: Vec<Rect> = if show_volumes {
             Layout::default()
-                .constraints([Constraint::Min(5), Constraint::Length(1)].as_ref())
+                .constraints([Constraint::Min(0), Constraint::Percentage(25)].as_ref())
                 .split(layout[1])
                 .to_vec()
         } else {


### PR DESCRIPTION
Determine the height for the stock charts using the available screen space rather than hard coding them to be 7/8 rows high. This is especially useful when one has just a tiny amount of stocks added, since in that case a bunch of space will be left unused without this change.

The height is calculated by taking the maximum available space for the stock charts, dividing it by the amount of stocks and then applying a minimum of 6 for the whole height. Later the constraint for the charts is set as the space reserved for the charts, so that the bottom-most chart is stretched to fill the rest of the space if there is any space remaining.

The amount of charts visible on the screen is constrained by setting a minimum height for one chart rather than setting a maximum for the amount of stocks displayed, since the former allows for more stocks to be displayed on larger screens/terminals with a smaller font size.

You can see the change in action in this image. Individual charts are stretched to fill the rest of the screen, including the slot reserved for the hidden help icon.

<img width="1918" height="1051" alt="image" src="https://github.com/user-attachments/assets/b014d188-92fd-4fca-a456-0aea3f272da1" />
