### PR TITLE
improve chart title truncating and the loading indicator

### DIFF
--- a/src/widget/stock.rs
+++ b/src/widget/stock.rs
@@ -1018,8 +1018,8 @@ pub fn get_chart_title(area: &Rect, state: &<StockWidget as StatefulWidget>::Sta
     // Take the loading indicator into account for the truncation calculation
     let loading_indicator_overhead = !state.loaded() as usize * 2;
 
-    // Constraint the title length to the screen area, add dots if it is truncated
-    let max_width = area.width as usize - 1 - loading_indicator_overhead;
+    // Constraint the title length to the screen area less padding & dots if it is truncated
+    let max_width = area.width as usize - 4 - loading_indicator_overhead;
     if title.len() > max_width {
         let width = (max_width - 3).max(0);
         title = format!("{}...", title[..width].trim_end());

--- a/src/widget/stock.rs
+++ b/src/widget/stock.rs
@@ -21,7 +21,8 @@ use crate::{
     SHOW_X_LABELS, THEME, TIME_FRAME, TRUNC_PRE,
 };
 
-const NUM_LOADING_TICKS: usize = 4;
+const NUM_LOADING_TICKS: usize = 8;
+const ICON_LOADING_TICKS: [char; 8] = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'];
 
 pub struct StockState {
     pub symbol: String,
@@ -104,7 +105,7 @@ impl StockState {
                 kagi_options,
                 ..Default::default()
             },
-            loading_tick: NUM_LOADING_TICKS,
+            loading_tick: 0,
             prev_state_loaded: false,
             chart_meta: None,
             cache_state: Default::default(),
@@ -547,10 +548,10 @@ impl StockState {
             // Reset tick
             if self.prev_state_loaded {
                 self.prev_state_loaded = false;
-                self.loading_tick = NUM_LOADING_TICKS;
+                self.loading_tick = 0;
             }
 
-            self.loading_tick = (self.loading_tick + 1) % (NUM_LOADING_TICKS + 1);
+            self.loading_tick = (self.loading_tick + 1) % NUM_LOADING_TICKS;
         } else if !self.prev_state_loaded {
             self.prev_state_loaded = true;
         }
@@ -602,30 +603,16 @@ impl CachableWidget<StockState> for StockWidget {
 
         let loaded = state.loaded();
 
-        let (company_name, currency) = match state.profile.as_ref() {
-            Some(profile) => (
-                profile.price.short_name.as_str(),
-                profile.price.currency.as_deref().unwrap_or("USD"),
-            ),
-            None => ("", ""),
+        let currency = match state.profile.as_ref() {
+            Some(profile) => profile.price.currency.as_deref().unwrap_or("USD"),
+            None => "",
         };
 
-        let loading_indicator = ".".repeat(state.loading_tick);
+        let title = get_chart_title(&area, state);
 
         // Draw widget block
         {
-            block::new(&format!(
-                " {}{:<4} ",
-                state.symbol,
-                if loaded {
-                    format!(" - {}", company_name)
-                } else if state.profile.is_some() {
-                    format!(" - {}{:<4}", company_name, loading_indicator)
-                } else {
-                    loading_indicator
-                }
-            ))
-            .render(area, buf);
+            block::new(&title).render(area, buf);
             area = add_padding(area, 1, PaddingDirection::All);
             area = add_padding(area, 1, PaddingDirection::Left);
             area = add_padding(area, 1, PaddingDirection::Right);
@@ -1014,4 +1001,32 @@ impl CachableWidget<StockState> for StockWidget {
             }
         }
     }
+}
+
+pub fn get_chart_title(area: &Rect, state: &<StockWidget as StatefulWidget>::State) -> String {
+    let company_name = match state.profile.as_ref() {
+        Some(profile) => profile.price.short_name.as_str(),
+        None => "",
+    };
+
+    // Add the company name if it is available
+    let mut title = match state.profile {
+        Some(_) => format!("{} - {}", state.symbol, company_name),
+        None => state.symbol.clone(),
+    };
+
+    // Constraint the title length to the screen area, add dots if it is truncated
+    let max_width = area.width as usize - 1;
+    if title.len() > max_width {
+        let width = (max_width - 3).max(0);
+        title = format!("{}...", title[..width].trim_end());
+    }
+
+    // Add padding and the loading indicator
+    title = match state.loaded() {
+        true => format!(" {} ", title),
+        false => format!(" {} {} ", title, ICON_LOADING_TICKS[state.loading_tick]),
+    };
+
+    title
 }

--- a/src/widget/stock.rs
+++ b/src/widget/stock.rs
@@ -1015,8 +1015,11 @@ pub fn get_chart_title(area: &Rect, state: &<StockWidget as StatefulWidget>::Sta
         None => state.symbol.clone(),
     };
 
+    // Take the loading indicator into account for the truncation calculation
+    let loading_indicator_overhead = !state.loaded() as usize * 2;
+
     // Constraint the title length to the screen area, add dots if it is truncated
-    let max_width = area.width as usize - 1;
+    let max_width = area.width as usize - 1 - loading_indicator_overhead;
     if title.len() > max_width {
         let width = (max_width - 3).max(0);
         title = format!("{}...", title[..width].trim_end());

--- a/src/widget/stock_summary.rs
+++ b/src/widget/stock_summary.rs
@@ -10,6 +10,7 @@ use super::{CachableWidget, CacheState};
 use crate::common::{format_decimals, ChartType};
 use crate::draw::{add_padding, PaddingDirection};
 use crate::theme::style;
+use crate::widget::stock;
 use crate::{ENABLE_PRE_POST, SHOW_VOLUMES, THEME};
 
 pub struct StockSummaryWidget {}
@@ -38,38 +39,15 @@ impl CachableWidget<StockState> for StockSummaryWidget {
 
         let loaded = state.loaded();
 
-        let (company_name, currency) = match state.profile.as_ref() {
-            Some(profile) => (
-                profile.price.short_name.as_str(),
-                profile.price.currency.as_deref().unwrap_or("USD"),
-            ),
-            None => ("", ""),
+        let currency = match state.profile.as_ref() {
+            Some(profile) => profile.price.currency.as_deref().unwrap_or("USD"),
+            None => "",
         };
 
-        let loading_indicator = ".".repeat(state.loading_tick);
+        let title = stock::get_chart_title(&area, state);
 
-        let title = &format!(
-            " {}{}",
-            state.symbol,
-            if state.profile.is_some() {
-                format!(" - {}", company_name)
-            } else {
-                "".to_string()
-            }
-        );
         Block::default()
-            .title(Span::styled(
-                format!(
-                    " {}{} ",
-                    &title[..24.min(title.len())],
-                    if loaded {
-                        "".to_string()
-                    } else {
-                        format!("{:<4}", loading_indicator)
-                    }
-                ),
-                style().fg(THEME.text_normal()),
-            ))
+            .title(Span::styled(title, style().fg(THEME.text_normal())))
             .borders(Borders::TOP)
             .border_style(style().fg(THEME.border_secondary()))
             .render(area, buf);


### PR DESCRIPTION
This PR changes how the title for each chart is constructed.
1. Unnecessary padding is removed.
2. The code is unified into a function so that both the summary view and the regular view can utilize it without repeating code.
3. The loading icon is changed into this much smaller and more beautiful one.
4. The arbitrarily set maximum title length of 24 is removed in place of calculating it each draw using the display dimensions. The title is truncated by adding three dots at the end.

Summary view:

<img width="806" height="391" alt="image" src="https://github.com/user-attachments/assets/09ddcf36-afa4-4c0c-ad82-dff52b5be63c" />

Regular view:

<img width="806" height="391" alt="image" src="https://github.com/user-attachments/assets/9b9211c4-be68-4d5a-90d4-f95faf0e790e" />